### PR TITLE
Issue #11: Add WHxxxx I2C display support

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -34,7 +34,7 @@
             "PREFETCH_ENABLE=1",
             "STM32F103xB",
             // "ITM_OUT=0",
-            // "DSPL_OUT=putc_dspl_wh2004",
+            "USE_WH_DISPLAY",
             "USART_OUT=USART1"
          ],
          "intelliSenseMode": "macos-clang-arm64",

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -35,11 +35,14 @@ extern "C" {
 /* Private includes ----------------------------------------------------------*/
 #include "common.h"
 #include "stm32f10x_it.h"
+#include "project_config.h"
 
 #include "gpio.h"
 #include "usart.h"
 #include "onewire.h"
 #include "spi.h"
+#include "i2c.h"
+#include "whxxxx.h"
 
 #include "heart_beat.h"
 #include "ds18b20.h"
@@ -50,11 +53,8 @@ extern "C" {
 
 /* Exported constants --------------------------------------------------------*/
 
-/* Exported defines -----------------------------------------------------------*/
-#define putc_dspl(ch) DSPL_OUT(ch);
-
 /* Exported variables --------------------------------------------------------*/
-// __IO uint32_t _PREG_;
+extern __IO uint32_t _PREG_;
 
 /* Private defines -----------------------------------------------------------*/
 /* Peripherals readiness flags */
@@ -62,6 +62,7 @@ extern "C" {
 #define _PR_USART1_BUS        1
 #define _PR_ONEWIRE_BUS       2
 #define _PR_SPI1_BUS          3
+#define _PR_I2C1_BUS          4
 
 /* Exported functions prototypes ---------------------------------------------*/
 

--- a/Core/Inc/project_config.h
+++ b/Core/Inc/project_config.h
@@ -13,6 +13,14 @@
 #define WH_DSPL_MODEL 1602
 #endif
 
+/*
+ * Temporary 3.3 V contrast workaround.
+ * Use 2 for the normal WH1602/WH2004 controller configuration.
+ */
+#ifndef WH_DSPL_LINE_MODE
+#define WH_DSPL_LINE_MODE 1
+#endif
+
 #define DSPL_OUT(ch) putc_dspl_wh(ch)
 #else
 #define DSPL_OUT(ch) ((void)(ch))

--- a/Core/Inc/project_config.h
+++ b/Core/Inc/project_config.h
@@ -1,0 +1,21 @@
+/**
+  ******************************************************************************
+  * @file           : project_config.h
+  * @brief          : Build-time feature selection and implementation mapping.
+  ******************************************************************************
+  */
+
+#ifndef __PROJECT_CONFIG_H
+#define __PROJECT_CONFIG_H
+
+#if defined(USE_WH_DISPLAY)
+#ifndef WH_DSPL_MODEL
+#define WH_DSPL_MODEL 1602
+#endif
+
+#define DSPL_OUT(ch) putc_dspl_wh(ch)
+#else
+#define DSPL_OUT(ch) ((void)(ch))
+#endif
+
+#endif /* __PROJECT_CONFIG_H */

--- a/Core/Src/common.c
+++ b/Core/Src/common.c
@@ -70,9 +70,11 @@ __STATIC_INLINE void _putc(uint8_t ch) {
     ITM_SendCharChannel(ch, ITM_OUT);
   #endif
 
-  #ifdef DSPL_OUT
-    putc_dspl(ch);
-   #endif
+  #if defined(USE_WH_DISPLAY)
+    if (!FLAG_CHECK(_PREG_, _PR_I2C1_BUS)) {
+      DSPL_OUT(ch);
+    }
+  #endif
 
   #ifdef USART_OUT
     while (!(PREG_CHECK(USART_OUT->SR, USART_SR_TXE_Pos)));

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -40,6 +40,12 @@ int main(void) {
       || (SPI_AdjustInit(SPI1) != SUCCESS)) {
     FLAG_SET(_PREG_, _PR_SPI1_BUS);
   }
+  #if defined(USE_WH_DISPLAY)
+    if ((I2C_Init(I2C1) != SUCCESS)
+        || (WHxxxx_Init(I2C1, WHxxxx_I2C_ADDR) != SUCCESS)) {
+      FLAG_SET(_PREG_, _PR_I2C1_BUS);
+    }
+  #endif
 
   if (!FLAG_CHECK(_PREG_, _PR_SPI1_BUS) && (W5500_Init() != 0)) {
     FLAG_SET(_PREG_, _PR_SPI1_BUS);
@@ -202,9 +208,9 @@ void SystemInit (void) {
   ));
 
   /* APB1 peripherals */
-  // SET_BIT(RCC->APB1ENR, (
-  //   RCC_APB1ENR_TIM7EN
-  // ));
+  #if defined(USE_WH_DISPLAY)
+    SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C1EN);
+  #endif
 
   /* APB2 peripherals */
   SET_BIT(RCC->APB2ENR, (

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ ASFLAGS += $(DEBUGFLAGS)
 endif
 
 ifeq ($(OUTPUT), 1)
-OUTPUTFLAGS = -DDSPL_OUT=putc_dspl_wh2004
+OUTPUTFLAGS = -DUSE_WH_DISPLAY
 ifeq ($(SYS), Darwin)
 OUTPUTFLAGS += -DITM_OUT=0 
 else ifeq ($(SYS), Linux)

--- a/Periph/Inc/i2c.h
+++ b/Periph/Inc/i2c.h
@@ -1,0 +1,29 @@
+/**
+  ******************************************************************************
+  * @file           : i2c.h
+  * @brief          : I2C master-mode peripheral interface.
+  ******************************************************************************
+  */
+
+#ifndef __I2C_H
+#define __I2C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "main.h"
+
+#define I2C1_SCL_Port GPIOB
+#define I2C1_SCL_Pin  GPIO_PIN_6
+#define I2C1_SDA_Port GPIOB
+#define I2C1_SDA_Pin  GPIO_PIN_7
+
+ErrorStatus I2C_Init(I2C_TypeDef*);
+ErrorStatus I2C_Master_Send(I2C_TypeDef*, uint8_t, const uint8_t*, uint16_t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __I2C_H */

--- a/Periph/Inc/whxxxx.h
+++ b/Periph/Inc/whxxxx.h
@@ -1,0 +1,28 @@
+/**
+  ******************************************************************************
+  * @file           : whxxxx.h
+  * @brief          : WHxxxx character display interface over I2C.
+  ******************************************************************************
+  */
+
+#ifndef __WHXXXX_H
+#define __WHXXXX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "main.h"
+
+#define WHxxxx_I2C_ADDR 0x27U
+
+ErrorStatus WHxxxx_Init(I2C_TypeDef*, uint8_t);
+ErrorStatus WHxxxx_Clear(void);
+ErrorStatus WHxxxx_Print(const uint8_t*, uint16_t);
+int putc_dspl_wh(char);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __WHXXXX_H */

--- a/Periph/Src/i2c.c
+++ b/Periph/Src/i2c.c
@@ -1,0 +1,116 @@
+/**
+  ******************************************************************************
+  * @file           : i2c.c
+  * @brief          : Polling I2C master-mode peripheral interface.
+  ******************************************************************************
+  */
+
+#include "i2c.h"
+
+#define I2C_BUS_TIMEOUT 100000U
+#define I2C_APB1_HZ     36000000U
+#define I2C_SPEED_HZ    100000U
+
+static ErrorStatus i2c_WaitSet(I2C_TypeDef*, uint32_t);
+static void i2c_Stop(I2C_TypeDef*);
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus I2C_Init(I2C_TypeDef* i2c) {
+  if (i2c != I2C1) return (ERROR);
+
+  uint32_t pinMode = GPIO_AF_OD | GPIO_IOS_2;
+  MODIFY_REG(
+    GPIOB->CRL,
+    GPIO_PIN_6_Mask | GPIO_PIN_7_Mask,
+    (pinMode << (I2C1_SCL_Pin * 4U)) | (pinMode << (I2C1_SDA_Pin * 4U))
+  );
+  PIN_H(I2C1_SCL_Port, I2C1_SCL_Pin);
+  PIN_H(I2C1_SDA_Port, I2C1_SDA_Pin);
+
+  CLEAR_BIT(i2c->CR1, I2C_CR1_PE);
+  SET_BIT(RCC->APB1RSTR, RCC_APB1RSTR_I2C1RST);
+  CLEAR_BIT(RCC->APB1RSTR, RCC_APB1RSTR_I2C1RST);
+
+  i2c->CR2 = I2C_APB1_HZ / 1000000U;
+  i2c->CCR = I2C_APB1_HZ / (2U * I2C_SPEED_HZ);
+  i2c->TRISE = (I2C_APB1_HZ / 1000000U) + 1U;
+  i2c->OAR1 = (1U << 14U);
+  SET_BIT(i2c->CR1, I2C_CR1_PE);
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus I2C_Master_Send(
+  I2C_TypeDef* i2c,
+  uint8_t slaveAddress,
+  const uint8_t* buffer,
+  uint16_t length
+) {
+  if ((i2c == NULL) || (buffer == NULL) || (length == 0U)) return (ERROR);
+
+  uint32_t timeout = I2C_BUS_TIMEOUT;
+  while ((READ_BIT(i2c->SR2, I2C_SR2_BUSY) != 0U) && (--timeout != 0U));
+  if (timeout == 0U) return (ERROR);
+
+  SET_BIT(i2c->CR1, I2C_CR1_START);
+  if (i2c_WaitSet(i2c, I2C_SR1_SB) != SUCCESS) {
+    i2c_Stop(i2c);
+    return (ERROR);
+  }
+
+  i2c->DR = (uint8_t)(slaveAddress << 1U);
+  if (i2c_WaitSet(i2c, I2C_SR1_ADDR) != SUCCESS) {
+    i2c_Stop(i2c);
+    return (ERROR);
+  }
+  (void)i2c->SR1;
+  (void)i2c->SR2;
+
+  for (uint16_t i = 0U; i < length; i++) {
+    if (i2c_WaitSet(i2c, I2C_SR1_TXE) != SUCCESS) {
+      i2c_Stop(i2c);
+      return (ERROR);
+    }
+    i2c->DR = buffer[i];
+  }
+
+  if (i2c_WaitSet(i2c, I2C_SR1_BTF) != SUCCESS) {
+    i2c_Stop(i2c);
+    return (ERROR);
+  }
+
+  i2c_Stop(i2c);
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus i2c_WaitSet(I2C_TypeDef* i2c, uint32_t mask) {
+  const uint32_t errorMask = I2C_SR1_BERR | I2C_SR1_ARLO | I2C_SR1_AF;
+  uint32_t timeout = I2C_BUS_TIMEOUT;
+  while (((i2c->SR1 & mask) == 0U)
+      && ((i2c->SR1 & errorMask) == 0U)
+      && (--timeout != 0U));
+  if ((i2c->SR1 & errorMask) != 0U) {
+    CLEAR_BIT(i2c->SR1, errorMask);
+    return (ERROR);
+  }
+  return (timeout == 0U) ? ERROR : SUCCESS;
+}
+
+
+
+
+// -------------------------------------------------------------
+static void i2c_Stop(I2C_TypeDef* i2c) {
+  SET_BIT(i2c->CR1, I2C_CR1_STOP);
+}

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -22,10 +22,19 @@
 #error "Unsupported WHxxxx display model"
 #endif
 
+#if (WH_DSPL_LINE_MODE == 1)
+#define WHXXXX_FUNCTION_SET 0x20U
+#elif (WH_DSPL_LINE_MODE == 2)
+#define WHXXXX_FUNCTION_SET 0x28U
+#else
+#error "WH_DSPL_LINE_MODE must be 1 or 2"
+#endif
+
 static I2C_TypeDef* displayI2C;
 static uint8_t displayAddress;
 static uint8_t displayRow;
 static uint8_t displayColumn;
+static FunctionalState displayReady;
 static SemaphoreHandle_t displayMutex;
 static StaticSemaphore_t displayMutexBuffer;
 
@@ -41,6 +50,7 @@ static void whxxxx_Unlock(void);
 
 // -------------------------------------------------------------
 ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
+  displayReady = DISABLE;
   displayI2C = i2c;
   displayAddress = address;
   displayRow = 0U;
@@ -58,12 +68,13 @@ ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
   if (whxxxx_WriteNibble(0x20U, 0U) != SUCCESS) return (ERROR);
   _delay_us(40U);
 
-  if (whxxxx_Command(0x20U) != SUCCESS) return (ERROR); /* 4-bit, 1-line font mode */
+  if (whxxxx_Command(WHXXXX_FUNCTION_SET) != SUCCESS) return (ERROR);
   if (whxxxx_Command(0x0CU) != SUCCESS) return (ERROR); /* Display on, cursor off */
   if (whxxxx_Command(0x01U) != SUCCESS) return (ERROR); /* Clear display */
   _delay_us(1640U);
   if (whxxxx_Command(0x06U) != SUCCESS) return (ERROR); /* Increment cursor */
 
+  displayReady = ENABLE;
   return (SUCCESS);
 }
 
@@ -72,6 +83,7 @@ ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
 
 // -------------------------------------------------------------
 ErrorStatus WHxxxx_Clear(void) {
+  if (displayReady != ENABLE) return (ERROR);
   if (whxxxx_Lock() != SUCCESS) return (ERROR);
   ErrorStatus status = whxxxx_Command(0x01U);
   if (status == SUCCESS) {
@@ -88,7 +100,7 @@ ErrorStatus WHxxxx_Clear(void) {
 
 // -------------------------------------------------------------
 ErrorStatus WHxxxx_Print(const uint8_t* buffer, uint16_t length) {
-  if (buffer == NULL) return (ERROR);
+  if ((displayReady != ENABLE) || (buffer == NULL)) return (ERROR);
   if (whxxxx_Lock() != SUCCESS) return (ERROR);
 
   ErrorStatus status = SUCCESS;
@@ -107,7 +119,9 @@ ErrorStatus WHxxxx_Print(const uint8_t* buffer, uint16_t length) {
 
 // -------------------------------------------------------------
 int putc_dspl_wh(char character) {
-  if ((displayI2C == NULL) || (displayMutex == NULL)) return (ERROR);
+  if ((displayReady != ENABLE) || (displayI2C == NULL) || (displayMutex == NULL)) {
+    return (ERROR);
+  }
   if (whxxxx_Lock() != SUCCESS) return (ERROR);
 
   ErrorStatus status = SUCCESS;

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -1,0 +1,210 @@
+/**
+  ******************************************************************************
+  * @file           : whxxxx.c
+  * @brief          : WHxxxx character display interface over an I2C backpack.
+  ******************************************************************************
+  */
+
+#include "whxxxx.h"
+#include "i2c.h"
+
+#define WHXXXX_BACKLIGHT       (1U << 3U)
+#define WHXXXX_ENABLE          (1U << 2U)
+#define WHXXXX_REGISTER_SELECT (1U << 0U)
+
+#if (WH_DSPL_MODEL == 1602)
+#define WHXXXX_COLUMNS 16U
+#define WHXXXX_ROWS    2U
+#elif (WH_DSPL_MODEL == 2004)
+#define WHXXXX_COLUMNS 20U
+#define WHXXXX_ROWS    4U
+#else
+#error "Unsupported WHxxxx display model"
+#endif
+
+static I2C_TypeDef* displayI2C;
+static uint8_t displayAddress;
+static uint8_t displayRow;
+static uint8_t displayColumn;
+static SemaphoreHandle_t displayMutex;
+static StaticSemaphore_t displayMutexBuffer;
+
+static ErrorStatus whxxxx_WriteNibble(uint8_t, uint8_t);
+static ErrorStatus whxxxx_WriteByte(uint8_t, uint8_t);
+static ErrorStatus whxxxx_Command(uint8_t);
+static ErrorStatus whxxxx_SetCursor(uint8_t, uint8_t);
+static ErrorStatus whxxxx_Lock(void);
+static void whxxxx_Unlock(void);
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
+  displayI2C = i2c;
+  displayAddress = address;
+  displayRow = 0U;
+  displayColumn = 0U;
+  displayMutex = xSemaphoreCreateMutexStatic(&displayMutexBuffer);
+  if (displayMutex == NULL) return (ERROR);
+
+  _delay_ms(40U);
+  if (whxxxx_WriteNibble(0x30U, 0U) != SUCCESS) return (ERROR);
+  _delay_us(4100U);
+  if (whxxxx_WriteNibble(0x30U, 0U) != SUCCESS) return (ERROR);
+  _delay_us(100U);
+  if (whxxxx_WriteNibble(0x30U, 0U) != SUCCESS) return (ERROR);
+  _delay_us(40U);
+  if (whxxxx_WriteNibble(0x20U, 0U) != SUCCESS) return (ERROR);
+  _delay_us(40U);
+
+  if (whxxxx_Command(0x20U) != SUCCESS) return (ERROR); /* 4-bit, 1-line font mode */
+  if (whxxxx_Command(0x0CU) != SUCCESS) return (ERROR); /* Display on, cursor off */
+  if (whxxxx_Command(0x01U) != SUCCESS) return (ERROR); /* Clear display */
+  _delay_us(1640U);
+  if (whxxxx_Command(0x06U) != SUCCESS) return (ERROR); /* Increment cursor */
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus WHxxxx_Clear(void) {
+  if (whxxxx_Lock() != SUCCESS) return (ERROR);
+  ErrorStatus status = whxxxx_Command(0x01U);
+  if (status == SUCCESS) {
+    _delay_us(1640U);
+    displayRow = 0U;
+    displayColumn = 0U;
+  }
+  whxxxx_Unlock();
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus WHxxxx_Print(const uint8_t* buffer, uint16_t length) {
+  if (buffer == NULL) return (ERROR);
+  if (whxxxx_Lock() != SUCCESS) return (ERROR);
+
+  ErrorStatus status = SUCCESS;
+  for (uint16_t i = 0U; (i < length) && (status == SUCCESS); i++) {
+    if (whxxxx_WriteByte(buffer[i], WHXXXX_REGISTER_SELECT) != SUCCESS) {
+      status = ERROR;
+    }
+  }
+
+  whxxxx_Unlock();
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+int putc_dspl_wh(char character) {
+  if ((displayI2C == NULL) || (displayMutex == NULL)) return (ERROR);
+  if (whxxxx_Lock() != SUCCESS) return (ERROR);
+
+  ErrorStatus status = SUCCESS;
+  if (character == '\n') {
+    displayRow++;
+    displayColumn = 0U;
+    if (displayRow >= WHXXXX_ROWS) {
+      status = whxxxx_Command(0x01U);
+      _delay_us(1640U);
+      displayRow = 0U;
+    } else {
+      status = whxxxx_SetCursor(displayRow, displayColumn);
+    }
+  } else if (character != '\r') {
+    if (displayColumn >= WHXXXX_COLUMNS) {
+      displayRow++;
+      displayColumn = 0U;
+      if (displayRow >= WHXXXX_ROWS) {
+        status = whxxxx_Command(0x01U);
+        _delay_us(1640U);
+        displayRow = 0U;
+      } else {
+        status = whxxxx_SetCursor(displayRow, displayColumn);
+      }
+    }
+    if (status == SUCCESS) {
+      status = whxxxx_WriteByte((uint8_t)character, WHXXXX_REGISTER_SELECT);
+      displayColumn++;
+    }
+  }
+
+  whxxxx_Unlock();
+  return (status == SUCCESS) ? (uint8_t)character : ERROR;
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus whxxxx_WriteNibble(uint8_t value, uint8_t flags) {
+  uint8_t bytes[2];
+  uint8_t output = (value & 0xF0U) | WHXXXX_BACKLIGHT | flags;
+  bytes[0] = output | WHXXXX_ENABLE;
+  bytes[1] = output;
+  return I2C_Master_Send(displayI2C, displayAddress, bytes, sizeof(bytes));
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus whxxxx_WriteByte(uint8_t value, uint8_t flags) {
+  uint8_t bytes[4];
+  uint8_t high = (value & 0xF0U) | WHXXXX_BACKLIGHT | flags;
+  uint8_t low = ((value << 4U) & 0xF0U) | WHXXXX_BACKLIGHT | flags;
+  bytes[0] = high | WHXXXX_ENABLE;
+  bytes[1] = high;
+  bytes[2] = low | WHXXXX_ENABLE;
+  bytes[3] = low;
+  ErrorStatus status = I2C_Master_Send(displayI2C, displayAddress, bytes, sizeof(bytes));
+  _delay_us(40U);
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus whxxxx_Command(uint8_t command) {
+  return whxxxx_WriteByte(command, 0U);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus whxxxx_SetCursor(uint8_t row, uint8_t column) {
+#if (WH_DSPL_MODEL == 1602)
+  static const uint8_t rowOffsets[WHXXXX_ROWS] = {0x00U, 0x40U};
+#else
+  static const uint8_t rowOffsets[WHXXXX_ROWS] = {0x00U, 0x40U, 0x14U, 0x54U};
+#endif
+  return whxxxx_Command(0x80U | (rowOffsets[row] + column));
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus whxxxx_Lock(void) {
+  return (xSemaphoreTake(displayMutex, portMAX_DELAY) == pdTRUE) ? SUCCESS : ERROR;
+}
+
+
+
+
+// -------------------------------------------------------------
+static void whxxxx_Unlock(void) {
+  (void)xSemaphoreGive(displayMutex);
+}

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -8,6 +8,8 @@
 #include "whxxxx.h"
 #include "i2c.h"
 
+#if defined(USE_WH_DISPLAY)
+
 #define WHXXXX_BACKLIGHT       (1U << 3U)
 #define WHXXXX_ENABLE          (1U << 2U)
 #define WHXXXX_REGISTER_SELECT (1U << 0U)
@@ -222,3 +224,5 @@ static ErrorStatus whxxxx_Lock(void) {
 static void whxxxx_Unlock(void) {
   (void)xSemaphoreGive(displayMutex);
 }
+
+#endif /* USE_WH_DISPLAY */

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -71,6 +71,7 @@ void TcpCommandService_Run(void) {
       if ((getSn_IR(TCP_COMMAND_SOCKET) & Sn_IR_CON) != 0U) {
         setSn_IR(TCP_COMMAND_SOCKET, Sn_IR_CON);
         commandLength = 0U;
+        printf("TCP connection\n");
       }
 
       tcpCommandService_Receive();


### PR DESCRIPTION
Closes #11

## Summary
- add an I2C1 master driver for PB6/PB7
- add WHxxxx support through a PCF8574 backpack at address `0x27`
- support WH1602 and WH2004 display geometry
- route configured display output through `DSPL_OUT`
- report TCP connection events on the display
- keep display feature and model selection in `project_config.h`
- avoid blocking normal logging when the display is unavailable

## Current configuration
- WH1602
- temporary one-line HD44780 initialization for improved contrast at 3.3 V

## Verification
- display-enabled firmware build passed
- display-disabled firmware build passed
- WH1602 firmware flashed and verified on the target with ST-Link