### PR TITLE
Issue #15: Optimize WHxxxx display output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,6 @@ dkms.conf
 
 # Builds
 build/
+build*/
 Core/.DS_Store
 .DS_Store

--- a/Core/Inc/project_config.h
+++ b/Core/Inc/project_config.h
@@ -18,7 +18,7 @@
  * Use 2 for the normal WH1602/WH2004 controller configuration.
  */
 #ifndef WH_DSPL_LINE_MODE
-#define WH_DSPL_LINE_MODE 2
+#define WH_DSPL_LINE_MODE 1
 #endif
 
 #define DSPL_OUT(ch) putc_dspl_wh(ch)

--- a/Core/Inc/project_config.h
+++ b/Core/Inc/project_config.h
@@ -18,7 +18,7 @@
  * Use 2 for the normal WH1602/WH2004 controller configuration.
  */
 #ifndef WH_DSPL_LINE_MODE
-#define WH_DSPL_LINE_MODE 1
+#define WH_DSPL_LINE_MODE 2
 #endif
 
 #define DSPL_OUT(ch) putc_dspl_wh(ch)

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -13,18 +13,15 @@
 #define WHXXXX_BACKLIGHT       (1U << 3U)
 #define WHXXXX_ENABLE          (1U << 2U)
 #define WHXXXX_REGISTER_SELECT (1U << 0U)
-#define WHXXXX_DISPLAY_SHIFT_LEFT 0x18U
 
 #if (WH_DSPL_MODEL == 1602)
 #define WHXXXX_COLUMNS           16U
 #define WHXXXX_ROWS              2U
-#define WHXXXX_ONE_LINE_LENGTH   24U
-#define WHXXXX_ONE_LINE_SHIFT    1U
+#define WHXXXX_ONE_LINE_LENGTH   16U
 #elif (WH_DSPL_MODEL == 2004)
 #define WHXXXX_COLUMNS           20U
 #define WHXXXX_ROWS              4U
 #define WHXXXX_ONE_LINE_LENGTH   40U
-#define WHXXXX_ONE_LINE_SHIFT    0U
 #else
 #error "Unsupported WHxxxx display model"
 #endif
@@ -176,11 +173,6 @@ int putc_dspl_wh(char character) {
       status = whxxxx_WriteByte((uint8_t)character, WHXXXX_REGISTER_SELECT);
       if (status == SUCCESS) {
         displayColumn++;
-#if (WHXXXX_ONE_LINE_SHIFT == 1U)
-        if (displayColumn > WHXXXX_COLUMNS) {
-          status = whxxxx_Command(WHXXXX_DISPLAY_SHIFT_LEFT);
-        }
-#endif
       }
     }
   }

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -45,6 +45,7 @@ static FunctionalState displayReady;
 static FunctionalState displayNewLinePending;
 #if (WH_DSPL_LINE_MODE == 2)
 static uint8_t displayLines[WHXXXX_ROWS][WHXXXX_COLUMNS];
+static FunctionalState displayRepaintPending;
 #endif
 static SemaphoreHandle_t displayMutex;
 static StaticSemaphore_t displayMutexBuffer;
@@ -77,6 +78,7 @@ ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
     }
   }
   displayNewLinePending = ENABLE;
+  displayRepaintPending = DISABLE;
 #endif
   displayMutex = xSemaphoreCreateMutexStatic(&displayMutexBuffer);
   if (displayMutex == NULL) return (ERROR);
@@ -121,6 +123,7 @@ ErrorStatus WHxxxx_Clear(void) {
       }
     }
     displayNewLinePending = ENABLE;
+    displayRepaintPending = DISABLE;
 #endif
   }
   whxxxx_Unlock();
@@ -259,13 +262,16 @@ static ErrorStatus whxxxx_SetCursor(uint8_t row, uint8_t column) {
 
 // -------------------------------------------------------------
 static ErrorStatus whxxxx_StartPrintfLine(void) {
-  for (uint8_t row = 0U; row < (WHXXXX_ROWS - 1U); row++) {
-    for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
-      displayLines[row][column] = displayLines[row + 1U][column];
+  if (displayRepaintPending == DISABLE) {
+    for (uint8_t row = 0U; row < (WHXXXX_ROWS - 1U); row++) {
+      for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
+        displayLines[row][column] = displayLines[row + 1U][column];
+      }
     }
-  }
-  for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
-    displayLines[WHXXXX_ROWS - 1U][column] = ' ';
+    for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
+      displayLines[WHXXXX_ROWS - 1U][column] = ' ';
+    }
+    displayRepaintPending = ENABLE;
   }
 
   ErrorStatus status = SUCCESS;
@@ -290,6 +296,7 @@ static ErrorStatus whxxxx_StartPrintfLine(void) {
     displayRow = WHXXXX_ROWS - 1U;
     displayColumn = 0U;
     displayNewLinePending = DISABLE;
+    displayRepaintPending = DISABLE;
   }
   return (status);
 }

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -14,15 +14,17 @@
 #define WHXXXX_ENABLE          (1U << 2U)
 #define WHXXXX_REGISTER_SELECT (1U << 0U)
 #define WHXXXX_DISPLAY_SHIFT_LEFT 0x18U
-#define WHXXXX_PRINTF_LINE_LENGTH 24U
-#define WHXXXX_PRINTF_COLUMNS     16U
 
 #if (WH_DSPL_MODEL == 1602)
-#define WHXXXX_COLUMNS 16U
-#define WHXXXX_ROWS    2U
+#define WHXXXX_COLUMNS           16U
+#define WHXXXX_ROWS              2U
+#define WHXXXX_ONE_LINE_LENGTH   24U
+#define WHXXXX_ONE_LINE_SHIFT    1U
 #elif (WH_DSPL_MODEL == 2004)
-#define WHXXXX_COLUMNS 20U
-#define WHXXXX_ROWS    4U
+#define WHXXXX_COLUMNS           20U
+#define WHXXXX_ROWS              4U
+#define WHXXXX_ONE_LINE_LENGTH   40U
+#define WHXXXX_ONE_LINE_SHIFT    0U
 #else
 #error "Unsupported WHxxxx display model"
 #endif
@@ -42,7 +44,7 @@ static uint8_t displayColumn;
 static FunctionalState displayReady;
 static FunctionalState displayNewLinePending;
 #if (WH_DSPL_LINE_MODE == 2)
-static uint8_t displayPreviousLine[WHXXXX_PRINTF_COLUMNS];
+static uint8_t displayLines[WHXXXX_ROWS][WHXXXX_COLUMNS];
 #endif
 static SemaphoreHandle_t displayMutex;
 static StaticSemaphore_t displayMutexBuffer;
@@ -69,8 +71,10 @@ ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
   displayColumn = 0U;
   displayNewLinePending = DISABLE;
 #if (WH_DSPL_LINE_MODE == 2)
-  for (uint8_t i = 0U; i < WHXXXX_PRINTF_COLUMNS; i++) {
-    displayPreviousLine[i] = ' ';
+  for (uint8_t row = 0U; row < WHXXXX_ROWS; row++) {
+    for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
+      displayLines[row][column] = ' ';
+    }
   }
   displayNewLinePending = ENABLE;
 #endif
@@ -111,8 +115,10 @@ ErrorStatus WHxxxx_Clear(void) {
     displayColumn = 0U;
     displayNewLinePending = DISABLE;
 #if (WH_DSPL_LINE_MODE == 2)
-    for (uint8_t i = 0U; i < WHXXXX_PRINTF_COLUMNS; i++) {
-      displayPreviousLine[i] = ' ';
+    for (uint8_t row = 0U; row < WHXXXX_ROWS; row++) {
+      for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
+        displayLines[row][column] = ' ';
+      }
     }
     displayNewLinePending = ENABLE;
 #endif
@@ -163,13 +169,15 @@ int putc_dspl_wh(char character) {
       displayNewLinePending = DISABLE;
     }
     if ((status == SUCCESS)
-        && (displayColumn < WHXXXX_PRINTF_LINE_LENGTH)) {
+        && (displayColumn < WHXXXX_ONE_LINE_LENGTH)) {
       status = whxxxx_WriteByte((uint8_t)character, WHXXXX_REGISTER_SELECT);
       if (status == SUCCESS) {
         displayColumn++;
+#if (WHXXXX_ONE_LINE_SHIFT == 1U)
         if (displayColumn > WHXXXX_COLUMNS) {
           status = whxxxx_Command(WHXXXX_DISPLAY_SHIFT_LEFT);
         }
+#endif
       }
     }
   }
@@ -181,10 +189,10 @@ int putc_dspl_wh(char character) {
       status = whxxxx_StartPrintfLine();
     }
     if ((status == SUCCESS)
-        && (displayColumn < WHXXXX_PRINTF_COLUMNS)) {
+        && (displayColumn < WHXXXX_COLUMNS)) {
       status = whxxxx_WriteByte((uint8_t)character, WHXXXX_REGISTER_SELECT);
       if (status == SUCCESS) {
-        displayPreviousLine[displayColumn] = (uint8_t)character;
+        displayLines[WHXXXX_ROWS - 1U][displayColumn] = (uint8_t)character;
         displayColumn++;
       }
     }
@@ -251,31 +259,35 @@ static ErrorStatus whxxxx_SetCursor(uint8_t row, uint8_t column) {
 
 // -------------------------------------------------------------
 static ErrorStatus whxxxx_StartPrintfLine(void) {
-  ErrorStatus status = whxxxx_SetCursor(0U, 0U);
-  for (uint8_t i = 0U;
-       (i < WHXXXX_PRINTF_COLUMNS) && (status == SUCCESS);
-       i++) {
-    status = whxxxx_WriteByte(
-      displayPreviousLine[i],
-      WHXXXX_REGISTER_SELECT
-    );
-    displayPreviousLine[i] = ' ';
+  for (uint8_t row = 0U; row < (WHXXXX_ROWS - 1U); row++) {
+    for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
+      displayLines[row][column] = displayLines[row + 1U][column];
+    }
+  }
+  for (uint8_t column = 0U; column < WHXXXX_COLUMNS; column++) {
+    displayLines[WHXXXX_ROWS - 1U][column] = ' ';
+  }
+
+  ErrorStatus status = SUCCESS;
+  for (uint8_t row = 0U;
+       (row < WHXXXX_ROWS) && (status == SUCCESS);
+       row++) {
+    status = whxxxx_SetCursor(row, 0U);
+    for (uint8_t column = 0U;
+         (column < WHXXXX_COLUMNS) && (status == SUCCESS);
+         column++) {
+      status = whxxxx_WriteByte(
+        displayLines[row][column],
+        WHXXXX_REGISTER_SELECT
+      );
+    }
   }
 
   if (status == SUCCESS) {
-    status = whxxxx_SetCursor(1U, 0U);
-  }
-  for (uint8_t i = 0U;
-       (i < WHXXXX_PRINTF_COLUMNS) && (status == SUCCESS);
-       i++) {
-    status = whxxxx_WriteByte(' ', WHXXXX_REGISTER_SELECT);
+    status = whxxxx_SetCursor(WHXXXX_ROWS - 1U, 0U);
   }
   if (status == SUCCESS) {
-    status = whxxxx_SetCursor(1U, 0U);
-  }
-
-  if (status == SUCCESS) {
-    displayRow = 1U;
+    displayRow = WHXXXX_ROWS - 1U;
     displayColumn = 0U;
     displayNewLinePending = DISABLE;
   }

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -13,6 +13,9 @@
 #define WHXXXX_BACKLIGHT       (1U << 3U)
 #define WHXXXX_ENABLE          (1U << 2U)
 #define WHXXXX_REGISTER_SELECT (1U << 0U)
+#define WHXXXX_DISPLAY_SHIFT_LEFT 0x18U
+#define WHXXXX_PRINTF_LINE_LENGTH 24U
+#define WHXXXX_PRINTF_COLUMNS     16U
 
 #if (WH_DSPL_MODEL == 1602)
 #define WHXXXX_COLUMNS 16U
@@ -37,13 +40,20 @@ static uint8_t displayAddress;
 static uint8_t displayRow;
 static uint8_t displayColumn;
 static FunctionalState displayReady;
+static FunctionalState displayNewLinePending;
+#if (WH_DSPL_LINE_MODE == 2)
+static uint8_t displayPreviousLine[WHXXXX_PRINTF_COLUMNS];
+#endif
 static SemaphoreHandle_t displayMutex;
 static StaticSemaphore_t displayMutexBuffer;
 
 static ErrorStatus whxxxx_WriteNibble(uint8_t, uint8_t);
 static ErrorStatus whxxxx_WriteByte(uint8_t, uint8_t);
 static ErrorStatus whxxxx_Command(uint8_t);
+#if (WH_DSPL_LINE_MODE == 2)
 static ErrorStatus whxxxx_SetCursor(uint8_t, uint8_t);
+static ErrorStatus whxxxx_StartPrintfLine(void);
+#endif
 static ErrorStatus whxxxx_Lock(void);
 static void whxxxx_Unlock(void);
 
@@ -57,6 +67,13 @@ ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
   displayAddress = address;
   displayRow = 0U;
   displayColumn = 0U;
+  displayNewLinePending = DISABLE;
+#if (WH_DSPL_LINE_MODE == 2)
+  for (uint8_t i = 0U; i < WHXXXX_PRINTF_COLUMNS; i++) {
+    displayPreviousLine[i] = ' ';
+  }
+  displayNewLinePending = ENABLE;
+#endif
   displayMutex = xSemaphoreCreateMutexStatic(&displayMutexBuffer);
   if (displayMutex == NULL) return (ERROR);
 
@@ -92,6 +109,13 @@ ErrorStatus WHxxxx_Clear(void) {
     _delay_us(1640U);
     displayRow = 0U;
     displayColumn = 0U;
+    displayNewLinePending = DISABLE;
+#if (WH_DSPL_LINE_MODE == 2)
+    for (uint8_t i = 0U; i < WHXXXX_PRINTF_COLUMNS; i++) {
+      displayPreviousLine[i] = ' ';
+    }
+    displayNewLinePending = ENABLE;
+#endif
   }
   whxxxx_Unlock();
   return (status);
@@ -127,33 +151,45 @@ int putc_dspl_wh(char character) {
   if (whxxxx_Lock() != SUCCESS) return (ERROR);
 
   ErrorStatus status = SUCCESS;
+#if (WH_DSPL_LINE_MODE == 1)
   if (character == '\n') {
-    displayRow++;
-    displayColumn = 0U;
-    if (displayRow >= WHXXXX_ROWS) {
+    displayNewLinePending = ENABLE;
+  } else if (character != '\r') {
+    if (displayNewLinePending == ENABLE) {
       status = whxxxx_Command(0x01U);
       _delay_us(1640U);
       displayRow = 0U;
-    } else {
-      status = whxxxx_SetCursor(displayRow, displayColumn);
-    }
-  } else if (character != '\r') {
-    if (displayColumn >= WHXXXX_COLUMNS) {
-      displayRow++;
       displayColumn = 0U;
-      if (displayRow >= WHXXXX_ROWS) {
-        status = whxxxx_Command(0x01U);
-        _delay_us(1640U);
-        displayRow = 0U;
-      } else {
-        status = whxxxx_SetCursor(displayRow, displayColumn);
+      displayNewLinePending = DISABLE;
+    }
+    if ((status == SUCCESS)
+        && (displayColumn < WHXXXX_PRINTF_LINE_LENGTH)) {
+      status = whxxxx_WriteByte((uint8_t)character, WHXXXX_REGISTER_SELECT);
+      if (status == SUCCESS) {
+        displayColumn++;
+        if (displayColumn > WHXXXX_COLUMNS) {
+          status = whxxxx_Command(WHXXXX_DISPLAY_SHIFT_LEFT);
+        }
       }
     }
-    if (status == SUCCESS) {
+  }
+#else
+  if (character == '\n') {
+    displayNewLinePending = ENABLE;
+  } else if (character != '\r') {
+    if (displayNewLinePending == ENABLE) {
+      status = whxxxx_StartPrintfLine();
+    }
+    if ((status == SUCCESS)
+        && (displayColumn < WHXXXX_PRINTF_COLUMNS)) {
       status = whxxxx_WriteByte((uint8_t)character, WHXXXX_REGISTER_SELECT);
-      displayColumn++;
+      if (status == SUCCESS) {
+        displayPreviousLine[displayColumn] = (uint8_t)character;
+        displayColumn++;
+      }
     }
   }
+#endif
 
   whxxxx_Unlock();
   return (status == SUCCESS) ? (uint8_t)character : ERROR;
@@ -200,6 +236,7 @@ static ErrorStatus whxxxx_Command(uint8_t command) {
 
 
 // -------------------------------------------------------------
+#if (WH_DSPL_LINE_MODE == 2)
 static ErrorStatus whxxxx_SetCursor(uint8_t row, uint8_t column) {
 #if (WH_DSPL_MODEL == 1602)
   static const uint8_t rowOffsets[WHXXXX_ROWS] = {0x00U, 0x40U};
@@ -208,6 +245,43 @@ static ErrorStatus whxxxx_SetCursor(uint8_t row, uint8_t column) {
 #endif
   return whxxxx_Command(0x80U | (rowOffsets[row] + column));
 }
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus whxxxx_StartPrintfLine(void) {
+  ErrorStatus status = whxxxx_SetCursor(0U, 0U);
+  for (uint8_t i = 0U;
+       (i < WHXXXX_PRINTF_COLUMNS) && (status == SUCCESS);
+       i++) {
+    status = whxxxx_WriteByte(
+      displayPreviousLine[i],
+      WHXXXX_REGISTER_SELECT
+    );
+    displayPreviousLine[i] = ' ';
+  }
+
+  if (status == SUCCESS) {
+    status = whxxxx_SetCursor(1U, 0U);
+  }
+  for (uint8_t i = 0U;
+       (i < WHXXXX_PRINTF_COLUMNS) && (status == SUCCESS);
+       i++) {
+    status = whxxxx_WriteByte(' ', WHXXXX_REGISTER_SELECT);
+  }
+  if (status == SUCCESS) {
+    status = whxxxx_SetCursor(1U, 0U);
+  }
+
+  if (status == SUCCESS) {
+    displayRow = 1U;
+    displayColumn = 0U;
+    displayNewLinePending = DISABLE;
+  }
+  return (status);
+}
+#endif
 
 
 

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -188,45 +188,47 @@ static void temperatureSensorService_PrintMeasurements(
   ErrorStatus bmx280Status,
   ErrorStatus bmx680Status
 ) {
-  printf("Sensors");
+  printf("DS18B20: ");
   if (ds18b20Status == SUCCESS) {
-    printf(" DS=");
     for (uint8_t i = 0U; i < ds18b20Count; i++) {
-      if (i > 0U) printf(",");
+      if (i > 0U) printf(", ");
       temperatureSensorService_PrintCentiDegrees(ds18b20Temperatures[i]);
     }
+    printf(" C");
   } else {
-    printf(" DS=ERR");
+    printf("conversion error");
   }
+  printf("\n");
 
   if (bmx280Status == SUCCESS) {
     BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
-    printf((device->DevID == BME280_ID) ? " BME280=" : " BMP280=");
+    printf((device->DevID == BME280_ID) ? "BME280: " : "BMP280: ");
     temperatureSensorService_PrintCentiDegrees(device->Results.temperature);
-    printf("/%lu", (unsigned long)device->Results.pressure);
+    printf(" C, %lu Pa", (unsigned long)device->Results.pressure);
     if (device->DevID == BME280_ID) {
       printf(
-        "/%lu.%03lu",
+        ", %lu.%03lu %%RH",
         (unsigned long)(device->Results.humidity / 1000U),
         (unsigned long)(device->Results.humidity % 1000U)
       );
     }
   } else {
-    printf(" BMx280=ERR");
+    printf("BMx280: conversion error");
   }
+  printf("\n");
 
   if (bmx680Status == SUCCESS) {
     BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
-    printf(" BME680=");
+    printf("BME680: ");
     temperatureSensorService_PrintCentiDegrees(device->Results.temperature);
     printf(
-      "/%lu/%lu.%03lu",
+      " C, %lu Pa, %lu.%03lu %%RH",
       (unsigned long)device->Results.pressure,
       (unsigned long)(device->Results.humidity / 1000U),
       (unsigned long)(device->Results.humidity % 1000U)
     );
   } else {
-    printf(" BME680=ERR");
+    printf("BME680: conversion error");
   }
   printf("\n");
 }


### PR DESCRIPTION
Closes #15

## Summary
- optimize `printf()` output for WH1602 and WH2004 displays
- add rolling 2×16 output for WH1602 in normal controller mode
- add rolling 4×20 output for WH2004 in normal controller mode
- retain the WH1602 one-line 24-character left-shift workaround
- add WH2004 one-line output across physical rows 1 and 3
- preserve display history when a multi-line repaint is retried after an I2C failure
- restore readable, line-by-line sensor conversion output

## Configuration
The committed project default remains WH1602 in one-line controller mode. WH2004 and normal multi-line modes are selected through the existing `WH_DSPL_MODEL` and `WH_DSPL_LINE_MODE` configuration macros.