### PR TITLE
Issue #19: optimize TCP sensor services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,6 @@ dkms.conf
 # Builds
 build/
 build*/
+test/*.log
 Core/.DS_Store
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ build*/
 test/*.log
 Core/.DS_Store
 .DS_Store
+
+# Log files
+*.log

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ARCH := $(shell uname -m)
 SYS := $(shell uname -s)
 # output
 OUTPUT = 1
-DISPLAY = WH
+DISPLAY = SSD
 
 #######################################
 # paths

--- a/Periph/Inc/bmxx80.h
+++ b/Periph/Inc/bmxx80.h
@@ -13,6 +13,8 @@
 #include "misc.h"
 #include "stm32f103xb.h"
 
+#define BMXX80_UNIQUE_ID_REG 0x83U
+
 typedef struct {
   uint32_t pressure;
   int32_t temperature;
@@ -73,6 +75,7 @@ typedef struct {
 
 typedef struct {
   uint8_t DevID;
+  uint32_t UniqueID;
   uint8_t* RawBufPtr;
   BMxX80_results_t Results;
   void* CalibPtr;

--- a/Periph/Inc/ds18b20.h
+++ b/Periph/Inc/ds18b20.h
@@ -21,14 +21,31 @@
 
 
 
+typedef enum {
+  DS18B20_STATUS_OK = 0U,
+  DS18B20_STATUS_BUS,
+  DS18B20_STATUS_TIMEOUT,
+  DS18B20_STATUS_CRC
+} DS18B20_Status_TypeDef;
+
+typedef struct {
+  uint8_t rom[8];
+  int16_t temperature;
+  DS18B20_Status_TypeDef status;
+} DS18B20_Measurement_TypeDef;
+
 /**
-  * @brief  Converts and reads temperatures from discovered DS18B20 devices.
-  * @param  temperatures Output array in hundredths of a degree Celsius.
-  * @param  capacity Number of elements available in temperatures.
-  * @param  count Number of temperatures written.
-  * @retval SUCCESS when at least one sensor was converted and read.
+  * @brief Converts and reads every discovered DS18B20 independently.
+  * @param measurements Per-device identity, value, and status output.
+  * @param capacity Number of elements available in measurements.
+  * @param count Number of discovered devices written.
+  * @retval SUCCESS when at least one discovered device was reported.
   */
-ErrorStatus DS18B20_MeasureTemperatures(int16_t*, uint8_t, uint8_t*);
+ErrorStatus DS18B20_Measure(
+  DS18B20_Measurement_TypeDef*,
+  uint8_t,
+  uint8_t*
+);
 
 
 /* Private defines -----------------------------------------------------------*/

--- a/Periph/Src/bmx280.c
+++ b/Periph/Src/bmx280.c
@@ -34,6 +34,13 @@ ErrorStatus BMx280_Init(BMxX80_TypeDef* dev) {
   if (bmx280_Receive(dev, BMX280_DEV_ID, 1U) != SUCCESS) goto done;
   dev->DevID = dev->RawBufPtr[0];
   if ((dev->DevID != BMP280_ID) && (dev->DevID != BME280_ID)) goto done;
+  if (bmx280_Receive(dev, BMXX80_UNIQUE_ID_REG, 4U) != SUCCESS) goto done;
+  dev->UniqueID = (
+      ((((uint32_t)dev->RawBufPtr[3]
+        + ((uint32_t)dev->RawBufPtr[2] << 8)) & 0x7FFFU) << 16)
+    | ((uint32_t)dev->RawBufPtr[1] << 8)
+    | (uint32_t)dev->RawBufPtr[0]
+  );
 
   if (bmx280_Send(dev, BMX280_RESET, BMX280_RESET_VALUE) != SUCCESS) goto done;
   if (bmx280_WaitNvmCopy(dev) != SUCCESS) goto done;

--- a/Periph/Src/bmx680.c
+++ b/Periph/Src/bmx680.c
@@ -31,6 +31,13 @@ ErrorStatus BMx680_Init(BMxX80_TypeDef* dev) {
   if (bmx680_Receive(dev, BMX680_DEV_ID, 1U) != SUCCESS) goto done;
   dev->DevID = dev->RawBufPtr[0];
   if (dev->DevID != BME680_ID) goto done;
+  if (bmx680_Receive(dev, BMXX80_UNIQUE_ID_REG, 4U) != SUCCESS) goto done;
+  dev->UniqueID = (
+      ((((uint32_t)dev->RawBufPtr[3]
+        + ((uint32_t)dev->RawBufPtr[2] << 8)) & 0x7FFFU) << 16)
+    | ((uint32_t)dev->RawBufPtr[1] << 8)
+    | (uint32_t)dev->RawBufPtr[0]
+  );
 
   BMx680_calib_t* calib = (BMx680_calib_t*)dev->CalibPtr;
   if (bmx680_Receive(dev, BMX680_CALIB1, 24U) != SUCCESS) goto done;

--- a/Periph/Src/ds18b20.c
+++ b/Periph/Src/ds18b20.c
@@ -12,6 +12,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "ds18b20.h"
+#include <string.h>
 
 
 /* Global variables ----------------------------------------------------------*/
@@ -22,22 +23,27 @@
 /* Private function prototypes -----------------------------------------------*/
 __STATIC_INLINE void dS18B20_Command(uint8_t);
 
-static ErrorStatus dS18B20_ReadScratchpad(uint8_t*, uint8_t*);
+static DS18B20_Status_TypeDef dS18B20_ReadScratchpad(uint8_t*, uint8_t*);
 
-static ErrorStatus dS18B20_ConvertTemperature(uint8_t*);
+static DS18B20_Status_TypeDef dS18B20_ConvertTemperature(uint8_t*);
 
 static ErrorStatus dS18B20_WaitStatus(uint16_t);
 
-static ErrorStatus DS18B20_GetTemperatureMeasurment(OneWireDevice_t*);
+static DS18B20_Status_TypeDef DS18B20_GetTemperatureMeasurement(
+  OneWireDevice_t*
+);
 
 static int16_t dS18B20_DecodeTemperature(const uint8_t*);
 
 // -------------------------------------------------------------
-ErrorStatus DS18B20_MeasureTemperatures(
-  int16_t* temperatures,
+ErrorStatus DS18B20_Measure(
+  DS18B20_Measurement_TypeDef* measurements,
   uint8_t capacity,
   uint8_t* count
 ) {
+  if ((measurements == NULL) || (count == NULL) || (capacity == 0U)) {
+    return (ERROR);
+  }
   *count = 0U;
   if (OneWire_Lock(portMAX_DELAY) != pdTRUE) return (ERROR);
 
@@ -50,11 +56,13 @@ ErrorStatus DS18B20_MeasureTemperatures(
 
   OneWireDevice_t* devices = Get_OwDevices();
   for (uint8_t i = 0; i < readCount; i++) {
-    if (DS18B20_GetTemperatureMeasurment(&devices[i]) != SUCCESS) {
-      OneWire_Unlock();
-      return (ERROR);
+    memcpy(measurements[i].rom, devices[i].addr, sizeof(measurements[i].rom));
+    measurements[i].status = DS18B20_GetTemperatureMeasurement(&devices[i]);
+    if (measurements[i].status == DS18B20_STATUS_OK) {
+      measurements[i].temperature = dS18B20_DecodeTemperature(devices[i].spad);
+    } else {
+      measurements[i].temperature = 0;
     }
-    temperatures[i] = dS18B20_DecodeTemperature(devices[i].spad);
   }
 
   *count = readCount;
@@ -82,9 +90,12 @@ __STATIC_INLINE void dS18B20_Command(uint8_t cmd) {
 
 
 // -------------------------------------------------------------  
-static ErrorStatus dS18B20_ReadScratchpad(uint8_t* buf, uint8_t* addr) {
+static DS18B20_Status_TypeDef dS18B20_ReadScratchpad(
+  uint8_t* buf,
+  uint8_t* addr
+) {
 
-  if (OneWire_MatchROM(addr)) return (ERROR);
+  if (OneWire_MatchROM(addr)) return (DS18B20_STATUS_BUS);
   dS18B20_Command(ReadScratchpad);
 
   uint8_t crc = 0;
@@ -92,23 +103,23 @@ static ErrorStatus dS18B20_ReadScratchpad(uint8_t* buf, uint8_t* addr) {
     OneWire_ReadByte(&buf[i]);
     crc = OneWire_CRC8(crc, buf[i]);
   }
-  if (crc) return (ERROR);
+  if (crc) return (DS18B20_STATUS_CRC);
   
-  return (SUCCESS);
+  return (DS18B20_STATUS_OK);
 }
 
 
 
 
 // -------------------------------------------------------------
-static ErrorStatus dS18B20_ConvertTemperature(uint8_t* addr) {
+static DS18B20_Status_TypeDef dS18B20_ConvertTemperature(uint8_t* addr) {
 
   if (*addr) {
     
-    if (OneWire_MatchROM(addr)) return (ERROR);
+    if (OneWire_MatchROM(addr)) return (DS18B20_STATUS_BUS);
     uint8_t pps = OneWire_ReadPowerSupply(addr);
     
-    if (OneWire_MatchROM(addr)) return (ERROR);
+    if (OneWire_MatchROM(addr)) return (DS18B20_STATUS_BUS);
     dS18B20_Command(ConvertT);
     
     if (pps) {
@@ -116,17 +127,21 @@ static ErrorStatus dS18B20_ConvertTemperature(uint8_t* addr) {
       vTaskDelay(pdMS_TO_TICKS(DS18B20_CONVERSION_TIMEOUT_MS));
       OneWire_StrongPullupDisable();
     } else {
-      if (dS18B20_WaitStatus(DS18B20_CONVERSION_TIMEOUT_MS) != SUCCESS) return (ERROR);
+      if (dS18B20_WaitStatus(DS18B20_CONVERSION_TIMEOUT_MS) != SUCCESS) {
+        return (DS18B20_STATUS_TIMEOUT);
+      }
     }
   } else {
-    if (OneWire_Reset()) return (ERROR);
+    if (OneWire_Reset()) return (DS18B20_STATUS_BUS);
     
     dS18B20_Command(SkipROM);
     dS18B20_Command(ConvertT);
-    if (dS18B20_WaitStatus(DS18B20_CONVERSION_TIMEOUT_MS) != SUCCESS) return (ERROR);
+    if (dS18B20_WaitStatus(DS18B20_CONVERSION_TIMEOUT_MS) != SUCCESS) {
+      return (DS18B20_STATUS_TIMEOUT);
+    }
   }
 
-  return (SUCCESS);
+  return (DS18B20_STATUS_OK);
 }
 
 
@@ -147,10 +162,11 @@ static ErrorStatus dS18B20_WaitStatus(uint16_t timeoutMs) {
 
 // -------------------------------------------------------------  
 // -------------------------------------------------------------  
-static ErrorStatus DS18B20_GetTemperatureMeasurment(OneWireDevice_t *dev) {
+static DS18B20_Status_TypeDef DS18B20_GetTemperatureMeasurement(
+  OneWireDevice_t* dev
+) {
+  DS18B20_Status_TypeDef status = dS18B20_ConvertTemperature(dev->addr);
+  if (status != DS18B20_STATUS_OK) return (status);
 
-  if (dS18B20_ConvertTemperature(dev->addr)) return (ERROR);
-  if (dS18B20_ReadScratchpad(dev->spad, dev->addr)) return (ERROR);
-
-  return (SUCCESS);
+  return dS18B20_ReadScratchpad(dev->spad, dev->addr);
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ a new conversion.
 | `get_t_X` | Recent temperature from temperature sensor `X` |
 | `get_p_X` | Recent pressure from pressure sensor `X` |
 | `get_h_X` | Recent relative humidity from humidity sensor `X` |
-| `get_tmpr` | Recent temperatures from all temperature sensors |
 | Unknown command | `ERR unknown_command\r\n` |
 
 Sensor numbers are one-based. Every command uses the same physical sensor list.
@@ -109,8 +108,7 @@ Diagnostic errors currently include `none`, `not_ready`, `timeout`, `crc`,
 measurement, the response contains `age_ms:unavailable`.
 
 Temperature is expressed in degrees Celsius, pressure in pascals, and relative
-humidity as a percentage. `get_tmpr` remains available for compatibility and
-returns all recent temperatures in one response.
+humidity as a percentage.
 
 Possible error responses include:
 
@@ -120,7 +118,6 @@ Possible error responses include:
 | `ERR sensor_not_found` | The requested physical sensor index does not exist |
 | `ERR measurement_not_supported` | The selected sensor does not provide the requested measurement type |
 | `ERR measurement_unavailable` | The sensor exists, but no valid recent measurement is available |
-| `ERR temperature_unavailable` | No complete result is available for the legacy `get_tmpr` command |
 | `ERR command_too_long` | The command exceeds the receive buffer |
 | `ERR unknown_command` | The command name is not supported |
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ a new conversion.
 | --- | --- |
 | `get_sensors` | Number of registered sensors by measurement type |
 | `get_model_X` | Model of physical sensor `X` |
+| `health_X` | Cached availability and health of physical sensor `X` |
 | `get_all_X` | All recent measurements from physical sensor `X` |
 | `get_t_X` | Recent temperature from temperature sensor `X` |
 | `get_p_X` | Recent pressure from pressure sensor `X` |
@@ -25,10 +26,13 @@ a new conversion.
 | `get_tmpr` | Recent temperatures from all temperature sensors |
 | Unknown command | `ERR unknown_command\r\n` |
 
-Sensor numbers are one-based. `get_model_X` and `get_all_X` use the physical
-sensor list. The temperature, pressure, and humidity commands each use their own
-capability-specific list. For example, `get_p_1` selects the first sensor that
-provides pressure, even if that device is not physical sensor 1.
+Sensor numbers are one-based. `get_model_X`, `health_X`, and `get_all_X` use the
+physical sensor list. The temperature, pressure, and humidity commands each use
+their own capability-specific list. For example, `get_p_1` selects the first
+sensor that provides pressure, even if that device is not physical sensor 1.
+Physical indexes remain assigned to the same registered sensor. DS18B20 devices
+are identified by their unique ROM addresses, so disconnecting one does not
+renumber the others.
 
 `get_sensors` returns counts in the following format:
 
@@ -50,6 +54,29 @@ get_t_1     -> OK 28.06
 get_p_1     -> OK 100099
 get_h_1     -> OK 46.419
 ```
+
+`health_X` reads service metadata and does not communicate with the sensor. A
+healthy response includes the model, time since the last successful measurement
+in milliseconds, consecutive failure count, and last error:
+
+```text
+health_1 -> OK model:DS18B20,state:healthy,age_ms:2150,failures:0,error:none
+```
+
+The possible health states are:
+
+| State | Meaning |
+| --- | --- |
+| `initializing` | Registered, but no successful measurement is available yet |
+| `healthy` | The latest periodic measurement succeeded |
+| `degraded` | One or two consecutive measurements failed |
+| `failed` | Three or more consecutive measurements failed |
+| `stale` | The last successful measurement is older than three service periods |
+| `missing` | A previously registered DS18B20 is absent from the latest discovery |
+
+Diagnostic errors currently include `none`, `not_ready`, `timeout`, `crc`,
+`bus`, `missing`, and `conversion`. When a sensor has never produced a valid
+measurement, the response contains `age_ms:unavailable`.
 
 Temperature is expressed in degrees Celsius, pressure in pascals, and relative
 humidity as a percentage. `get_tmpr` remains available for compatibility and

--- a/README.md
+++ b/README.md
@@ -5,20 +5,19 @@
 ### Features
 
 * Straightforward peripheral initialization
-* TCP command service on port 5005
+* TCP measurement service on port 5005
+* TCP sensor information and health service on port 5006
 
-### TCP commands
+### TCP measurement commands
 
-Commands may be terminated with `CR`, `LF`, or `CRLF`.
+Measurement commands listen on TCP port 5005. Commands may be terminated with
+`CR`, `LF`, or `CRLF`.
 The server sends one response and then closes the connection. Sensor commands
 return cached results from the periodic measurement service; they do not start
 a new conversion.
 
 | Command | Response |
 | --- | --- |
-| `get_sensors` | Number of registered sensors by measurement type |
-| `get_model_X` | Model of physical sensor `X` |
-| `health_X` | Cached availability and health of physical sensor `X` |
 | `get_all_X` | All recent measurements from physical sensor `X` |
 | `get_t_X` | Recent temperature from temperature sensor `X` |
 | `get_p_X` | Recent pressure from pressure sensor `X` |
@@ -26,13 +25,37 @@ a new conversion.
 | `get_tmpr` | Recent temperatures from all temperature sensors |
 | Unknown command | `ERR unknown_command\r\n` |
 
-Sensor numbers are one-based. `get_model_X`, `health_X`, and `get_all_X` use the
-physical sensor list. The temperature, pressure, and humidity commands each use
-their own capability-specific list. For example, `get_p_1` selects the first
-sensor that provides pressure, even if that device is not physical sensor 1.
+Sensor numbers are one-based. Every command uses the same physical sensor list.
+For example, if physical sensor 1 is a DS18B20, `get_t_1` returns its
+temperature while `get_p_1` and `get_h_1` return
+`ERR measurement_not_supported`.
+
+Example responses:
+
+```text
+get_all_1   -> OK model:DS18B20,t:28.06
+get_all_3   -> OK model:BME280,t:26.98,p:100099,h:46.419
+get_t_1     -> OK 28.06
+get_p_1     -> OK 100099
+get_h_1     -> OK 46.419
+```
+
+### TCP sensor information and health
+
+Sensor information and health checks listen on a separate WIZnet socket on TCP
+port 5006.
+
+| Command | Response |
+| --- | --- |
+| `get_sensors` | Number of registered sensors by measurement type |
+| `get_model_X` | Model of physical sensor `X` |
+| `get_sn_X` | Serial number of physical sensor `X` |
+| `health_X` | Cached availability and health of physical sensor `X` |
+
+These commands use the same one-based physical sensor list as `get_all_X`.
 Physical indexes remain assigned to the same registered sensor. DS18B20 devices
-are identified by their unique ROM addresses, so disconnecting one does not
-renumber the others.
+are identified by their unique 64-bit ROM addresses, so disconnecting one does
+not renumber the others.
 
 `get_sensors` returns counts in the following format:
 
@@ -44,23 +67,30 @@ Here, `all` is the number of physical sensors. A sensor that provides multiple
 measurement types is counted once in `all` and once in each applicable type.
 Gas measurements are reserved for a future protocol extension.
 
-Example responses:
+Information examples:
 
 ```text
 get_model_1 -> OK DS18B20
-get_all_1   -> OK model:DS18B20,t:28.06
-get_all_3   -> OK model:BME280,t:26.98,p:100099,h:46.419
-get_t_1     -> OK 28.06
-get_p_1     -> OK 100099
-get_h_1     -> OK 46.419
+get_sn_1    -> OK 28FF641D2A1603B7
 ```
 
-`health_X` reads service metadata and does not communicate with the sensor. A
-healthy response includes the model, time since the last successful measurement
-in milliseconds, consecutive failure count, and last error:
+DS18B20 serial numbers are returned as 16 uppercase hexadecimal digits. Bosch
+sensor serial numbers use the per-device 31-bit Unique ID and are returned as
+eight uppercase hexadecimal digits.
+
+`health_X` reads cached service metadata and does not communicate with the
+sensor. A healthy response includes the model, time since the last successful
+measurement in milliseconds, consecutive failure count, and last error:
 
 ```text
 health_1 -> OK model:DS18B20,state:healthy,age_ms:2150,failures:0,error:none
+```
+
+Example using Netcat:
+
+```console
+$ printf 'health_1\r\n' | nc 192.168.1.10 5006
+OK model:DS18B20,state:healthy,age_ms:2150,failures:0,error:none
 ```
 
 The possible health states are:
@@ -87,7 +117,8 @@ Possible error responses include:
 | Response | Meaning |
 | --- | --- |
 | `ERR invalid_sensor_number` | The index is missing, zero, malformed, or too large |
-| `ERR sensor_not_found` | The requested physical or capability-specific index does not exist |
+| `ERR sensor_not_found` | The requested physical sensor index does not exist |
+| `ERR measurement_not_supported` | The selected sensor does not provide the requested measurement type |
 | `ERR measurement_unavailable` | The sensor exists, but no valid recent measurement is available |
 | `ERR temperature_unavailable` | No complete result is available for the legacy `get_tmpr` command |
 | `ERR command_too_long` | The command exceeds the receive buffer |
@@ -96,10 +127,10 @@ Possible error responses include:
 Example using Netcat, with the device at `192.168.1.10`:
 
 ```console
-$ printf 'get_sensors\r\n' | nc 192.168.1.10 5005
-OK t:4,h:2,p:2,all:4
 $ printf 'get_all_3\r\n' | nc 192.168.1.10 5005
 OK model:BME280,t:26.98,p:100099,h:46.419
+$ printf 'get_sensors\r\n' | nc 192.168.1.10 5006
+OK t:4,h:2,p:2,all:4
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,21 +10,69 @@
 ### TCP commands
 
 Commands may be terminated with `CR`, `LF`, or `CRLF`.
+The server sends one response and then closes the connection. Sensor commands
+return cached results from the periodic measurement service; they do not start
+a new conversion.
 
 | Command | Response |
 | --- | --- |
-| `get_tmpr` | `OK <latest-temperature> [<latest-temperature>]\r\n` |
+| `get_sensors` | Number of registered sensors by measurement type |
+| `get_model_X` | Model of physical sensor `X` |
+| `get_all_X` | All recent measurements from physical sensor `X` |
+| `get_t_X` | Recent temperature from temperature sensor `X` |
+| `get_p_X` | Recent pressure from pressure sensor `X` |
+| `get_h_X` | Recent relative humidity from humidity sensor `X` |
+| `get_tmpr` | Recent temperatures from all temperature sensors |
 | Unknown command | `ERR unknown_command\r\n` |
 
-The `get_tmpr` command returns the most recent periodic measurement without
-starting a new conversion. Until the first measurement is available, it returns
-`ERR temperature_unavailable\r\n`.
+Sensor numbers are one-based. `get_model_X` and `get_all_X` use the physical
+sensor list. The temperature, pressure, and humidity commands each use their own
+capability-specific list. For example, `get_p_1` selects the first sensor that
+provides pressure, even if that device is not physical sensor 1.
+
+`get_sensors` returns counts in the following format:
+
+```text
+OK t:4,h:2,p:2,all:4
+```
+
+Here, `all` is the number of physical sensors. A sensor that provides multiple
+measurement types is counted once in `all` and once in each applicable type.
+Gas measurements are reserved for a future protocol extension.
+
+Example responses:
+
+```text
+get_model_1 -> OK DS18B20
+get_all_1   -> OK model:DS18B20,t:28.06
+get_all_3   -> OK model:BME280,t:26.98,p:100099,h:46.419
+get_t_1     -> OK 28.06
+get_p_1     -> OK 100099
+get_h_1     -> OK 46.419
+```
+
+Temperature is expressed in degrees Celsius, pressure in pascals, and relative
+humidity as a percentage. `get_tmpr` remains available for compatibility and
+returns all recent temperatures in one response.
+
+Possible error responses include:
+
+| Response | Meaning |
+| --- | --- |
+| `ERR invalid_sensor_number` | The index is missing, zero, malformed, or too large |
+| `ERR sensor_not_found` | The requested physical or capability-specific index does not exist |
+| `ERR measurement_unavailable` | The sensor exists, but no valid recent measurement is available |
+| `ERR temperature_unavailable` | No complete result is available for the legacy `get_tmpr` command |
+| `ERR command_too_long` | The command exceeds the receive buffer |
+| `ERR unknown_command` | The command name is not supported |
 
 Example using Netcat, with the device at `192.168.1.10`:
 
 ```console
-$ printf 'get_tmpr\r\n' | nc 192.168.1.10 5005
-OK 23.50 24.06
+$ printf 'get_sensors\r\n' | nc 192.168.1.10 5005
+OK t:4,h:2,p:2,all:4
+$ printf 'get_all_3\r\n' | nc 192.168.1.10 5005
+OK model:BME280,t:26.98,p:100099,h:46.419
 ```
 
 ---

--- a/Srv/Inc/temperature_service.h
+++ b/Srv/Inc/temperature_service.h
@@ -49,6 +49,7 @@ typedef struct {
   SensorModel_TypeDef model;
   uint8_t capabilities;
   uint8_t identity[8];
+  uint32_t serialNumber;
   BaseType_t dataValid;
   int32_t temperature;
   uint32_t pressure;

--- a/Srv/Inc/temperature_service.h
+++ b/Srv/Inc/temperature_service.h
@@ -26,13 +26,38 @@ typedef enum {
   SENSOR_CAPABILITY_HUMIDITY    = (1U << 2U)
 } SensorCapability_TypeDef;
 
+typedef enum {
+  SENSOR_HEALTH_INITIALIZING = 0U,
+  SENSOR_HEALTH_HEALTHY,
+  SENSOR_HEALTH_DEGRADED,
+  SENSOR_HEALTH_FAILED,
+  SENSOR_HEALTH_STALE,
+  SENSOR_HEALTH_MISSING
+} SensorHealthState_TypeDef;
+
+typedef enum {
+  SENSOR_ERROR_NONE = 0U,
+  SENSOR_ERROR_NOT_READY,
+  SENSOR_ERROR_TIMEOUT,
+  SENSOR_ERROR_CRC,
+  SENSOR_ERROR_BUS,
+  SENSOR_ERROR_MISSING,
+  SENSOR_ERROR_CONVERSION
+} SensorError_TypeDef;
+
 typedef struct {
   SensorModel_TypeDef model;
   uint8_t capabilities;
+  uint8_t identity[8];
   BaseType_t dataValid;
   int32_t temperature;
   uint32_t pressure;
   uint32_t humidity;
+  TickType_t lastAttempt;
+  TickType_t lastSuccess;
+  uint16_t consecutiveFailures;
+  SensorHealthState_TypeDef health;
+  SensorError_TypeDef lastError;
 } SensorSnapshot_TypeDef;
 
 typedef struct {

--- a/Srv/Inc/temperature_service.h
+++ b/Srv/Inc/temperature_service.h
@@ -74,10 +74,5 @@ ErrorStatus TemperatureSensorService_GetSnapshot(
   uint8_t,
   SensorSnapshot_TypeDef*
 );
-ErrorStatus TemperatureSensorService_GetByCapability(
-  SensorCapability_TypeDef,
-  uint8_t,
-  SensorSnapshot_TypeDef*
-);
 
 #endif /* __TEMPERATURE_SERVICE_H */

--- a/Srv/Inc/temperature_service.h
+++ b/Srv/Inc/temperature_service.h
@@ -10,11 +10,48 @@
 
 #include "main.h"
 
+#define SENSOR_SERVICE_MAX_DS18B20 6U
+#define SENSOR_SERVICE_MAX_DEVICES (SENSOR_SERVICE_MAX_DS18B20 + 2U)
+
+typedef enum {
+  SENSOR_MODEL_DS18B20 = 0U,
+  SENSOR_MODEL_BMP280,
+  SENSOR_MODEL_BME280,
+  SENSOR_MODEL_BME680
+} SensorModel_TypeDef;
+
+typedef enum {
+  SENSOR_CAPABILITY_TEMPERATURE = (1U << 0U),
+  SENSOR_CAPABILITY_PRESSURE    = (1U << 1U),
+  SENSOR_CAPABILITY_HUMIDITY    = (1U << 2U)
+} SensorCapability_TypeDef;
+
+typedef struct {
+  SensorModel_TypeDef model;
+  uint8_t capabilities;
+  BaseType_t dataValid;
+  int32_t temperature;
+  uint32_t pressure;
+  uint32_t humidity;
+} SensorSnapshot_TypeDef;
+
+typedef struct {
+  uint8_t temperature;
+  uint8_t pressure;
+  uint8_t humidity;
+  uint8_t all;
+} SensorCounts_TypeDef;
+
 void TemperatureSensorService_Init(void);
-ErrorStatus TemperatureSensorService_GetRecentDs18b20(
-  int16_t*,
+void TemperatureSensorService_GetCounts(SensorCounts_TypeDef*);
+ErrorStatus TemperatureSensorService_GetSnapshot(
   uint8_t,
-  uint8_t*
+  SensorSnapshot_TypeDef*
+);
+ErrorStatus TemperatureSensorService_GetByCapability(
+  SensorCapability_TypeDef,
+  uint8_t,
+  SensorSnapshot_TypeDef*
 );
 
 #endif /* __TEMPERATURE_SERVICE_H */

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -12,17 +12,26 @@
 
 #define TCP_COMMAND_SOCKET      2U
 #define TCP_COMMAND_PORT        5005U
+#define TCP_HEALTH_SOCKET       3U
+#define TCP_HEALTH_PORT         5006U
 #define TCP_COMMAND_BUFFER_SIZE 64U
 #define TCP_RESPONSE_SIZE       128U
 
 static uint8_t commandBuffer[TCP_COMMAND_BUFFER_SIZE];
 static uint16_t commandLength;
+static uint8_t healthBuffer[TCP_COMMAND_BUFFER_SIZE];
+static uint16_t healthLength;
 
 static void tcpCommandService_Task(void*);
 static void tcpCommandService_Receive(void);
 static void tcpCommandService_ProcessInput(void);
 static void tcpCommandService_ProcessCommand(const uint8_t*, uint16_t);
 static ErrorStatus tcpCommandService_Send(const char*);
+static void tcpHealthService_Run(void);
+static void tcpHealthService_Receive(void);
+static void tcpHealthService_ProcessInput(void);
+static void tcpHealthService_ProcessCommand(const uint8_t*, uint16_t);
+static ErrorStatus tcpHealthService_Send(const char*);
 static ErrorStatus tcpCommandService_ParseSensorNumber(
   const uint8_t*,
   uint16_t,
@@ -65,6 +74,7 @@ static void tcpCommandService_Task(void* parameters) {
   while (1) {
     if (SPI_Enable(SPI1) == SUCCESS) {
       TcpCommandService_Run();
+      tcpHealthService_Run();
       (void) SPI_Disable(SPI1);
     }
     vTaskDelay(1U);
@@ -119,6 +129,54 @@ void TcpCommandService_Run(void) {
 
 
 // -------------------------------------------------------------
+static void tcpHealthService_Run(void) {
+  switch (getSn_SR(TCP_HEALTH_SOCKET)) {
+    case SOCK_ESTABLISHED:
+      if ((getSn_IR(TCP_HEALTH_SOCKET) & Sn_IR_CON) != 0U) {
+        setSn_IR(TCP_HEALTH_SOCKET, Sn_IR_CON);
+        healthLength = 0U;
+        printf("Service info connection\n");
+      }
+      tcpHealthService_Receive();
+      break;
+
+    case SOCK_CLOSE_WAIT:
+      if (getSn_RX_RSR(TCP_HEALTH_SOCKET) > 0U) {
+        tcpHealthService_Receive();
+      }
+      if (getSn_SR(TCP_HEALTH_SOCKET) == SOCK_CLOSE_WAIT) {
+        (void)disconnect(TCP_HEALTH_SOCKET);
+        healthLength = 0U;
+      }
+      break;
+
+    case SOCK_INIT:
+      if (listen(TCP_HEALTH_SOCKET) != SOCK_OK) {
+        (void)close(TCP_HEALTH_SOCKET);
+      }
+      break;
+
+    case SOCK_CLOSED:
+      healthLength = 0U;
+      if (socket(
+            TCP_HEALTH_SOCKET,
+            Sn_MR_TCP,
+            TCP_HEALTH_PORT,
+            0x00
+          ) != TCP_HEALTH_SOCKET) {
+        (void)close(TCP_HEALTH_SOCKET);
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
 static void tcpCommandService_Receive(void) {
   uint16_t receivedSize = getSn_RX_RSR(TCP_COMMAND_SOCKET);
   if (receivedSize == 0U) return;
@@ -140,6 +198,37 @@ static void tcpCommandService_Receive(void) {
 
   commandLength += (uint16_t)result;
   tcpCommandService_ProcessInput();
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpHealthService_Receive(void) {
+  uint16_t receivedSize = getSn_RX_RSR(TCP_HEALTH_SOCKET);
+  if (receivedSize == 0U) return;
+
+  uint16_t available = TCP_COMMAND_BUFFER_SIZE - healthLength;
+  uint16_t readSize = (receivedSize < available) ? receivedSize : available;
+  if (readSize == 0U) {
+    (void)tcpHealthService_Send("ERR command_too_long\r\n");
+    healthLength = 0U;
+    return;
+  }
+
+  int32_t result = recv(
+    TCP_HEALTH_SOCKET,
+    &healthBuffer[healthLength],
+    readSize
+  );
+  if (result <= 0) {
+    (void)close(TCP_HEALTH_SOCKET);
+    healthLength = 0U;
+    return;
+  }
+
+  healthLength += (uint16_t)result;
+  tcpHealthService_ProcessInput();
 }
 
 
@@ -173,6 +262,38 @@ static void tcpCommandService_ProcessInput(void) {
   } else if (commandLength == TCP_COMMAND_BUFFER_SIZE) {
     (void) tcpCommandService_Send("ERR command_too_long\r\n");
     commandLength = 0U;
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpHealthService_ProcessInput(void) {
+  uint16_t commandStart = 0U;
+
+  for (uint16_t i = 0U; i < healthLength; i++) {
+    if ((healthBuffer[i] == '\r') || (healthBuffer[i] == '\n')) {
+      if (i > commandStart) {
+        tcpHealthService_ProcessCommand(
+          &healthBuffer[commandStart],
+          i - commandStart
+        );
+        healthLength = 0U;
+        return;
+      }
+      commandStart = i + 1U;
+    }
+  }
+
+  if (commandStart > 0U) {
+    uint16_t remaining = healthLength - commandStart;
+    memmove(healthBuffer, &healthBuffer[commandStart], remaining);
+    healthLength = remaining;
+  }
+  if (healthLength == TCP_COMMAND_BUFFER_SIZE) {
+    (void)tcpHealthService_Send("ERR command_too_long\r\n");
+    healthLength = 0U;
   }
 }
 
@@ -221,26 +342,8 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
     return;
   }
 
-  if ((length == 11U) && (memcmp(command, "get_sensors", 11U) == 0)) {
-    SensorCounts_TypeDef counts;
-    TemperatureSensorService_GetCounts(&counts);
-    (void)snprintf(
-      response,
-      sizeof(response),
-      "OK t:%u,h:%u,p:%u,all:%u\r\n",
-      counts.temperature,
-      counts.humidity,
-      counts.pressure,
-      counts.all
-    );
-    (void) tcpCommandService_Send(response);
-    return;
-  }
-
   typedef enum {
     TCP_SENSOR_COMMAND_NONE = 0U,
-    TCP_SENSOR_COMMAND_MODEL,
-    TCP_SENSOR_COMMAND_HEALTH,
     TCP_SENSOR_COMMAND_ALL,
     TCP_SENSOR_COMMAND_TEMPERATURE,
     TCP_SENSOR_COMMAND_PRESSURE,
@@ -249,13 +352,7 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
 
   TcpSensorCommand_TypeDef commandType = TCP_SENSOR_COMMAND_NONE;
   uint16_t prefixLength = 0U;
-  if ((length > 10U) && (memcmp(command, "get_model_", 10U) == 0)) {
-    commandType = TCP_SENSOR_COMMAND_MODEL;
-    prefixLength = 10U;
-  } else if ((length > 7U) && (memcmp(command, "health_", 7U) == 0)) {
-    commandType = TCP_SENSOR_COMMAND_HEALTH;
-    prefixLength = 7U;
-  } else if ((length > 8U) && (memcmp(command, "get_all_", 8U) == 0)) {
+  if ((length > 8U) && (memcmp(command, "get_all_", 8U) == 0)) {
     commandType = TCP_SENSOR_COMMAND_ALL;
     prefixLength = 8U;
   } else if ((length > 6U) && (memcmp(command, "get_t_", 6U) == 0)) {
@@ -286,66 +383,28 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   }
 
   SensorSnapshot_TypeDef snapshot;
-  ErrorStatus lookupStatus;
-  if ((commandType == TCP_SENSOR_COMMAND_MODEL)
-      || (commandType == TCP_SENSOR_COMMAND_HEALTH)
-      || (commandType == TCP_SENSOR_COMMAND_ALL)) {
-    lookupStatus = TemperatureSensorService_GetSnapshot(sensorNumber, &snapshot);
-  } else {
-    SensorCapability_TypeDef capability = SENSOR_CAPABILITY_TEMPERATURE;
-    if (commandType == TCP_SENSOR_COMMAND_PRESSURE) {
-      capability = SENSOR_CAPABILITY_PRESSURE;
-    } else if (commandType == TCP_SENSOR_COMMAND_HUMIDITY) {
-      capability = SENSOR_CAPABILITY_HUMIDITY;
-    }
-    lookupStatus = TemperatureSensorService_GetByCapability(
-      capability,
-      sensorNumber,
-      &snapshot
-    );
-  }
-  if (lookupStatus != SUCCESS) {
+  if (TemperatureSensorService_GetSnapshot(
+        sensorNumber,
+        &snapshot
+      ) != SUCCESS) {
     (void) tcpCommandService_Send("ERR sensor_not_found\r\n");
     return;
   }
 
-  if (commandType == TCP_SENSOR_COMMAND_MODEL) {
-    (void)snprintf(
-      response,
-      sizeof(response),
-      "OK %s\r\n",
-      tcpCommandService_ModelName(snapshot.model)
-    );
-    (void)tcpCommandService_Send(response);
+  uint8_t requiredCapability = 0U;
+  if (commandType == TCP_SENSOR_COMMAND_TEMPERATURE) {
+    requiredCapability = SENSOR_CAPABILITY_TEMPERATURE;
+  } else if (commandType == TCP_SENSOR_COMMAND_PRESSURE) {
+    requiredCapability = SENSOR_CAPABILITY_PRESSURE;
+  } else if (commandType == TCP_SENSOR_COMMAND_HUMIDITY) {
+    requiredCapability = SENSOR_CAPABILITY_HUMIDITY;
+  }
+  if ((requiredCapability != 0U)
+      && ((snapshot.capabilities & requiredCapability) == 0U)) {
+    (void)tcpCommandService_Send("ERR measurement_not_supported\r\n");
     return;
   }
-  if (commandType == TCP_SENSOR_COMMAND_HEALTH) {
-    if (snapshot.lastSuccess == 0U) {
-      (void)snprintf(
-        response,
-        sizeof(response),
-        "OK model:%s,state:%s,age_ms:unavailable,failures:%u,error:%s\r\n",
-        tcpCommandService_ModelName(snapshot.model),
-        tcpCommandService_HealthName(snapshot.health),
-        snapshot.consecutiveFailures,
-        tcpCommandService_ErrorName(snapshot.lastError)
-      );
-    } else {
-      TickType_t age = xTaskGetTickCount() - snapshot.lastSuccess;
-      (void)snprintf(
-        response,
-        sizeof(response),
-        "OK model:%s,state:%s,age_ms:%lu,failures:%u,error:%s\r\n",
-        tcpCommandService_ModelName(snapshot.model),
-        tcpCommandService_HealthName(snapshot.health),
-        (unsigned long)(age * portTICK_PERIOD_MS),
-        snapshot.consecutiveFailures,
-        tcpCommandService_ErrorName(snapshot.lastError)
-      );
-    }
-    (void)tcpCommandService_Send(response);
-    return;
-  }
+
   if (snapshot.dataValid != pdTRUE) {
     (void)tcpCommandService_Send("ERR measurement_unavailable\r\n");
     return;
@@ -393,6 +452,141 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
     response[used] = '\0';
   }
   (void)tcpCommandService_Send(response);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpHealthService_ProcessCommand(
+  const uint8_t* command,
+  uint16_t length
+) {
+  char response[TCP_RESPONSE_SIZE];
+
+  if ((length == 11U) && (memcmp(command, "get_sensors", 11U) == 0)) {
+    SensorCounts_TypeDef counts;
+    TemperatureSensorService_GetCounts(&counts);
+    (void)snprintf(
+      response,
+      sizeof(response),
+      "OK t:%u,h:%u,p:%u,all:%u\r\n",
+      counts.temperature,
+      counts.humidity,
+      counts.pressure,
+      counts.all
+    );
+    (void)tcpHealthService_Send(response);
+    return;
+  }
+
+  typedef enum {
+    TCP_INFO_COMMAND_NONE = 0U,
+    TCP_INFO_COMMAND_MODEL,
+    TCP_INFO_COMMAND_SERIAL,
+    TCP_INFO_COMMAND_HEALTH
+  } TcpInfoCommand_TypeDef;
+
+  TcpInfoCommand_TypeDef commandType = TCP_INFO_COMMAND_NONE;
+  uint16_t prefixLength = 0U;
+  if ((length > 10U) && (memcmp(command, "get_model_", 10U) == 0)) {
+    commandType = TCP_INFO_COMMAND_MODEL;
+    prefixLength = 10U;
+  } else if ((length > 7U) && (memcmp(command, "get_sn_", 7U) == 0)) {
+    commandType = TCP_INFO_COMMAND_SERIAL;
+    prefixLength = 7U;
+  } else if ((length > 7U) && (memcmp(command, "health_", 7U) == 0)) {
+    commandType = TCP_INFO_COMMAND_HEALTH;
+    prefixLength = 7U;
+  }
+
+  if (commandType == TCP_INFO_COMMAND_NONE) {
+    (void)tcpHealthService_Send("ERR unknown_command\r\n");
+    return;
+  }
+
+  uint8_t sensorNumber;
+  if (tcpCommandService_ParseSensorNumber(
+        command,
+        length,
+        prefixLength,
+        &sensorNumber
+      ) != SUCCESS) {
+    (void)tcpHealthService_Send("ERR invalid_sensor_number\r\n");
+    return;
+  }
+
+  SensorSnapshot_TypeDef snapshot;
+  if (TemperatureSensorService_GetSnapshot(
+        sensorNumber,
+        &snapshot
+      ) != SUCCESS) {
+    (void)tcpHealthService_Send("ERR sensor_not_found\r\n");
+    return;
+  }
+
+  if (commandType == TCP_INFO_COMMAND_MODEL) {
+    (void)snprintf(
+      response,
+      sizeof(response),
+      "OK %s\r\n",
+      tcpCommandService_ModelName(snapshot.model)
+    );
+    (void)tcpHealthService_Send(response);
+    return;
+  }
+
+  if (commandType == TCP_INFO_COMMAND_SERIAL) {
+    if (snapshot.model == SENSOR_MODEL_DS18B20) {
+      (void)snprintf(
+        response,
+        sizeof(response),
+        "OK %02X%02X%02X%02X%02X%02X%02X%02X\r\n",
+        snapshot.identity[0],
+        snapshot.identity[1],
+        snapshot.identity[2],
+        snapshot.identity[3],
+        snapshot.identity[4],
+        snapshot.identity[5],
+        snapshot.identity[6],
+        snapshot.identity[7]
+      );
+    } else {
+      (void)snprintf(
+        response,
+        sizeof(response),
+        "OK %08lX\r\n",
+        (unsigned long)snapshot.serialNumber
+      );
+    }
+    (void)tcpHealthService_Send(response);
+    return;
+  }
+
+  if (snapshot.lastSuccess == 0U) {
+    (void)snprintf(
+      response,
+      sizeof(response),
+      "OK model:%s,state:%s,age_ms:unavailable,failures:%u,error:%s\r\n",
+      tcpCommandService_ModelName(snapshot.model),
+      tcpCommandService_HealthName(snapshot.health),
+      snapshot.consecutiveFailures,
+      tcpCommandService_ErrorName(snapshot.lastError)
+    );
+  } else {
+    TickType_t age = xTaskGetTickCount() - snapshot.lastSuccess;
+    (void)snprintf(
+      response,
+      sizeof(response),
+      "OK model:%s,state:%s,age_ms:%lu,failures:%u,error:%s\r\n",
+      tcpCommandService_ModelName(snapshot.model),
+      tcpCommandService_HealthName(snapshot.health),
+      (unsigned long)(age * portTICK_PERIOD_MS),
+      snapshot.consecutiveFailures,
+      tcpCommandService_ErrorName(snapshot.lastError)
+    );
+  }
+  (void)tcpHealthService_Send(response);
 }
 
 
@@ -577,5 +771,47 @@ static ErrorStatus tcpCommandService_Send(const char* response) {
   setSn_IR(TCP_COMMAND_SOCKET, Sn_IR_SENDOK);
   (void) disconnect(TCP_COMMAND_SOCKET);
   commandLength = 0U;
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus tcpHealthService_Send(const char* response) {
+  uint16_t length = (uint16_t)strlen(response);
+  uint16_t sent = 0U;
+
+  while (sent < length) {
+    int32_t result = send(
+      TCP_HEALTH_SOCKET,
+      (uint8_t*)&response[sent],
+      length - sent
+    );
+    if (result <= 0) {
+      (void)close(TCP_HEALTH_SOCKET);
+      return (ERROR);
+    }
+    sent += (uint16_t)result;
+  }
+
+  TickType_t start = xTaskGetTickCount();
+  TickType_t timeout = pdMS_TO_TICKS(1000U);
+  while ((getSn_IR(TCP_HEALTH_SOCKET) & Sn_IR_SENDOK) == 0U) {
+    uint8_t status = getSn_SR(TCP_HEALTH_SOCKET);
+    if ((status != SOCK_ESTABLISHED) && (status != SOCK_CLOSE_WAIT)) {
+      (void)close(TCP_HEALTH_SOCKET);
+      return (ERROR);
+    }
+    if ((xTaskGetTickCount() - start) >= timeout) {
+      (void)close(TCP_HEALTH_SOCKET);
+      return (ERROR);
+    }
+    vTaskDelay(1U);
+  }
+
+  setSn_IR(TCP_HEALTH_SOCKET, Sn_IR_SENDOK);
+  (void)disconnect(TCP_HEALTH_SOCKET);
+  healthLength = 0U;
   return (SUCCESS);
 }

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -30,6 +30,8 @@ static ErrorStatus tcpCommandService_ParseSensorNumber(
   uint8_t*
 );
 static const char* tcpCommandService_ModelName(SensorModel_TypeDef);
+static const char* tcpCommandService_HealthName(SensorHealthState_TypeDef);
+static const char* tcpCommandService_ErrorName(SensorError_TypeDef);
 static void tcpCommandService_AppendTemperature(char*, size_t, size_t*, int16_t);
 static void tcpCommandService_AppendPressure(char*, size_t, size_t*, uint32_t);
 static void tcpCommandService_AppendHumidity(char*, size_t, size_t*, uint32_t);
@@ -238,6 +240,7 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   typedef enum {
     TCP_SENSOR_COMMAND_NONE = 0U,
     TCP_SENSOR_COMMAND_MODEL,
+    TCP_SENSOR_COMMAND_HEALTH,
     TCP_SENSOR_COMMAND_ALL,
     TCP_SENSOR_COMMAND_TEMPERATURE,
     TCP_SENSOR_COMMAND_PRESSURE,
@@ -249,6 +252,9 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   if ((length > 10U) && (memcmp(command, "get_model_", 10U) == 0)) {
     commandType = TCP_SENSOR_COMMAND_MODEL;
     prefixLength = 10U;
+  } else if ((length > 7U) && (memcmp(command, "health_", 7U) == 0)) {
+    commandType = TCP_SENSOR_COMMAND_HEALTH;
+    prefixLength = 7U;
   } else if ((length > 8U) && (memcmp(command, "get_all_", 8U) == 0)) {
     commandType = TCP_SENSOR_COMMAND_ALL;
     prefixLength = 8U;
@@ -282,6 +288,7 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   SensorSnapshot_TypeDef snapshot;
   ErrorStatus lookupStatus;
   if ((commandType == TCP_SENSOR_COMMAND_MODEL)
+      || (commandType == TCP_SENSOR_COMMAND_HEALTH)
       || (commandType == TCP_SENSOR_COMMAND_ALL)) {
     lookupStatus = TemperatureSensorService_GetSnapshot(sensorNumber, &snapshot);
   } else {
@@ -309,6 +316,33 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
       "OK %s\r\n",
       tcpCommandService_ModelName(snapshot.model)
     );
+    (void)tcpCommandService_Send(response);
+    return;
+  }
+  if (commandType == TCP_SENSOR_COMMAND_HEALTH) {
+    if (snapshot.lastSuccess == 0U) {
+      (void)snprintf(
+        response,
+        sizeof(response),
+        "OK model:%s,state:%s,age_ms:unavailable,failures:%u,error:%s\r\n",
+        tcpCommandService_ModelName(snapshot.model),
+        tcpCommandService_HealthName(snapshot.health),
+        snapshot.consecutiveFailures,
+        tcpCommandService_ErrorName(snapshot.lastError)
+      );
+    } else {
+      TickType_t age = xTaskGetTickCount() - snapshot.lastSuccess;
+      (void)snprintf(
+        response,
+        sizeof(response),
+        "OK model:%s,state:%s,age_ms:%lu,failures:%u,error:%s\r\n",
+        tcpCommandService_ModelName(snapshot.model),
+        tcpCommandService_HealthName(snapshot.health),
+        (unsigned long)(age * portTICK_PERIOD_MS),
+        snapshot.consecutiveFailures,
+        tcpCommandService_ErrorName(snapshot.lastError)
+      );
+    }
     (void)tcpCommandService_Send(response);
     return;
   }
@@ -394,6 +428,41 @@ static const char* tcpCommandService_ModelName(SensorModel_TypeDef model) {
     case SENSOR_MODEL_BME280:  return ("BME280");
     case SENSOR_MODEL_BME680:  return ("BME680");
     default:                   return ("unknown");
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static const char* tcpCommandService_HealthName(
+  SensorHealthState_TypeDef health
+) {
+  switch (health) {
+    case SENSOR_HEALTH_INITIALIZING: return ("initializing");
+    case SENSOR_HEALTH_HEALTHY:      return ("healthy");
+    case SENSOR_HEALTH_DEGRADED:     return ("degraded");
+    case SENSOR_HEALTH_FAILED:       return ("failed");
+    case SENSOR_HEALTH_STALE:        return ("stale");
+    case SENSOR_HEALTH_MISSING:      return ("missing");
+    default:                         return ("unknown");
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static const char* tcpCommandService_ErrorName(SensorError_TypeDef error) {
+  switch (error) {
+    case SENSOR_ERROR_NONE:       return ("none");
+    case SENSOR_ERROR_NOT_READY:  return ("not_ready");
+    case SENSOR_ERROR_TIMEOUT:    return ("timeout");
+    case SENSOR_ERROR_CRC:        return ("crc");
+    case SENSOR_ERROR_BUS:        return ("bus");
+    case SENSOR_ERROR_MISSING:    return ("missing");
+    case SENSOR_ERROR_CONVERSION: return ("conversion");
+    default:                      return ("unknown");
   }
 }
 

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -13,8 +13,7 @@
 #define TCP_COMMAND_SOCKET      2U
 #define TCP_COMMAND_PORT        5005U
 #define TCP_COMMAND_BUFFER_SIZE 64U
-#define TCP_RESPONSE_SIZE       64U
-#define TCP_MAX_TEMPERATURES    2U
+#define TCP_RESPONSE_SIZE       128U
 
 static uint8_t commandBuffer[TCP_COMMAND_BUFFER_SIZE];
 static uint16_t commandLength;
@@ -24,7 +23,16 @@ static void tcpCommandService_Receive(void);
 static void tcpCommandService_ProcessInput(void);
 static void tcpCommandService_ProcessCommand(const uint8_t*, uint16_t);
 static ErrorStatus tcpCommandService_Send(const char*);
+static ErrorStatus tcpCommandService_ParseSensorNumber(
+  const uint8_t*,
+  uint16_t,
+  uint16_t,
+  uint8_t*
+);
+static const char* tcpCommandService_ModelName(SensorModel_TypeDef);
 static void tcpCommandService_AppendTemperature(char*, size_t, size_t*, int16_t);
+static void tcpCommandService_AppendPressure(char*, size_t, size_t*, uint32_t);
+static void tcpCommandService_AppendHumidity(char*, size_t, size_t*, uint32_t);
 
 
 
@@ -171,35 +179,298 @@ static void tcpCommandService_ProcessInput(void) {
 
 // -------------------------------------------------------------
 static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t length) {
+  char response[TCP_RESPONSE_SIZE];
+  size_t used = 0U;
+
+  /* Preserve the original command as an alias returning all temperatures. */
   if ((length == 8U) && (memcmp(command, "get_tmpr", 8U) == 0)) {
-    int16_t temperatures[TCP_MAX_TEMPERATURES];
-    uint8_t count = 0U;
-    char response[TCP_RESPONSE_SIZE];
-    size_t used = 0U;
-
-    if (TemperatureSensorService_GetRecentDs18b20(
-          temperatures,
-          TCP_MAX_TEMPERATURES,
-          &count
-        ) != SUCCESS) {
-      (void) tcpCommandService_Send("ERR temperature_unavailable\r\n");
-      return;
-    }
-
+    SensorCounts_TypeDef counts;
+    TemperatureSensorService_GetCounts(&counts);
     used = (size_t)snprintf(response, sizeof(response), "OK");
-    for (uint8_t i = 0U; (i < count) && (used < sizeof(response)); i++) {
-      tcpCommandService_AppendTemperature(response, sizeof(response), &used, temperatures[i]);
+    for (uint8_t i = 1U; i <= counts.temperature; i++) {
+      SensorSnapshot_TypeDef snapshot;
+      if ((TemperatureSensorService_GetByCapability(
+             SENSOR_CAPABILITY_TEMPERATURE,
+             i,
+             &snapshot
+           ) != SUCCESS)
+          || (snapshot.dataValid != pdTRUE)) {
+        (void)tcpCommandService_Send("ERR temperature_unavailable\r\n");
+        return;
+      }
+      response[used++] = ' ';
+      tcpCommandService_AppendTemperature(
+        response,
+        sizeof(response),
+        &used,
+        snapshot.temperature
+      );
+    }
+    if (counts.temperature == 0U) {
+      (void)tcpCommandService_Send("ERR temperature_unavailable\r\n");
+      return;
     }
     if (used < (sizeof(response) - 2U)) {
       response[used++] = '\r';
       response[used++] = '\n';
       response[used] = '\0';
     }
+    (void)tcpCommandService_Send(response);
+    return;
+  }
+
+  if ((length == 11U) && (memcmp(command, "get_sensors", 11U) == 0)) {
+    SensorCounts_TypeDef counts;
+    TemperatureSensorService_GetCounts(&counts);
+    (void)snprintf(
+      response,
+      sizeof(response),
+      "OK t:%u,h:%u,p:%u,all:%u\r\n",
+      counts.temperature,
+      counts.humidity,
+      counts.pressure,
+      counts.all
+    );
     (void) tcpCommandService_Send(response);
     return;
   }
 
-  (void) tcpCommandService_Send("ERR unknown_command\r\n");
+  typedef enum {
+    TCP_SENSOR_COMMAND_NONE = 0U,
+    TCP_SENSOR_COMMAND_MODEL,
+    TCP_SENSOR_COMMAND_ALL,
+    TCP_SENSOR_COMMAND_TEMPERATURE,
+    TCP_SENSOR_COMMAND_PRESSURE,
+    TCP_SENSOR_COMMAND_HUMIDITY
+  } TcpSensorCommand_TypeDef;
+
+  TcpSensorCommand_TypeDef commandType = TCP_SENSOR_COMMAND_NONE;
+  uint16_t prefixLength = 0U;
+  if ((length > 10U) && (memcmp(command, "get_model_", 10U) == 0)) {
+    commandType = TCP_SENSOR_COMMAND_MODEL;
+    prefixLength = 10U;
+  } else if ((length > 8U) && (memcmp(command, "get_all_", 8U) == 0)) {
+    commandType = TCP_SENSOR_COMMAND_ALL;
+    prefixLength = 8U;
+  } else if ((length > 6U) && (memcmp(command, "get_t_", 6U) == 0)) {
+    commandType = TCP_SENSOR_COMMAND_TEMPERATURE;
+    prefixLength = 6U;
+  } else if ((length > 6U) && (memcmp(command, "get_p_", 6U) == 0)) {
+    commandType = TCP_SENSOR_COMMAND_PRESSURE;
+    prefixLength = 6U;
+  } else if ((length > 6U) && (memcmp(command, "get_h_", 6U) == 0)) {
+    commandType = TCP_SENSOR_COMMAND_HUMIDITY;
+    prefixLength = 6U;
+  }
+
+  if (commandType == TCP_SENSOR_COMMAND_NONE) {
+    (void) tcpCommandService_Send("ERR unknown_command\r\n");
+    return;
+  }
+
+  uint8_t sensorNumber;
+  if (tcpCommandService_ParseSensorNumber(
+        command,
+        length,
+        prefixLength,
+        &sensorNumber
+      ) != SUCCESS) {
+    (void) tcpCommandService_Send("ERR invalid_sensor_number\r\n");
+    return;
+  }
+
+  SensorSnapshot_TypeDef snapshot;
+  ErrorStatus lookupStatus;
+  if ((commandType == TCP_SENSOR_COMMAND_MODEL)
+      || (commandType == TCP_SENSOR_COMMAND_ALL)) {
+    lookupStatus = TemperatureSensorService_GetSnapshot(sensorNumber, &snapshot);
+  } else {
+    SensorCapability_TypeDef capability = SENSOR_CAPABILITY_TEMPERATURE;
+    if (commandType == TCP_SENSOR_COMMAND_PRESSURE) {
+      capability = SENSOR_CAPABILITY_PRESSURE;
+    } else if (commandType == TCP_SENSOR_COMMAND_HUMIDITY) {
+      capability = SENSOR_CAPABILITY_HUMIDITY;
+    }
+    lookupStatus = TemperatureSensorService_GetByCapability(
+      capability,
+      sensorNumber,
+      &snapshot
+    );
+  }
+  if (lookupStatus != SUCCESS) {
+    (void) tcpCommandService_Send("ERR sensor_not_found\r\n");
+    return;
+  }
+
+  if (commandType == TCP_SENSOR_COMMAND_MODEL) {
+    (void)snprintf(
+      response,
+      sizeof(response),
+      "OK %s\r\n",
+      tcpCommandService_ModelName(snapshot.model)
+    );
+    (void)tcpCommandService_Send(response);
+    return;
+  }
+  if (snapshot.dataValid != pdTRUE) {
+    (void)tcpCommandService_Send("ERR measurement_unavailable\r\n");
+    return;
+  }
+
+  used = (size_t)snprintf(response, sizeof(response), "OK");
+  if ((commandType == TCP_SENSOR_COMMAND_ALL)
+      || (commandType == TCP_SENSOR_COMMAND_TEMPERATURE)) {
+    if (commandType == TCP_SENSOR_COMMAND_ALL) {
+      used += (size_t)snprintf(
+        &response[used],
+        sizeof(response) - used,
+        " model:%s,t:",
+        tcpCommandService_ModelName(snapshot.model)
+      );
+    } else {
+      response[used++] = ' ';
+    }
+    tcpCommandService_AppendTemperature(
+      response,
+      sizeof(response),
+      &used,
+      snapshot.temperature
+    );
+  }
+  if ((commandType == TCP_SENSOR_COMMAND_ALL)
+      && ((snapshot.capabilities & SENSOR_CAPABILITY_PRESSURE) != 0U)) {
+    used += (size_t)snprintf(&response[used], sizeof(response) - used, ",p:");
+    tcpCommandService_AppendPressure(response, sizeof(response), &used, snapshot.pressure);
+  } else if (commandType == TCP_SENSOR_COMMAND_PRESSURE) {
+    response[used++] = ' ';
+    tcpCommandService_AppendPressure(response, sizeof(response), &used, snapshot.pressure);
+  }
+  if ((commandType == TCP_SENSOR_COMMAND_ALL)
+      && ((snapshot.capabilities & SENSOR_CAPABILITY_HUMIDITY) != 0U)) {
+    used += (size_t)snprintf(&response[used], sizeof(response) - used, ",h:");
+    tcpCommandService_AppendHumidity(response, sizeof(response), &used, snapshot.humidity);
+  } else if (commandType == TCP_SENSOR_COMMAND_HUMIDITY) {
+    response[used++] = ' ';
+    tcpCommandService_AppendHumidity(response, sizeof(response), &used, snapshot.humidity);
+  }
+  if (used < (sizeof(response) - 2U)) {
+    response[used++] = '\r';
+    response[used++] = '\n';
+    response[used] = '\0';
+  }
+  (void)tcpCommandService_Send(response);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus tcpCommandService_ParseSensorNumber(
+  const uint8_t* command,
+  uint16_t length,
+  uint16_t prefixLength,
+  uint8_t* sensorNumber
+) {
+  if ((sensorNumber == NULL) || (prefixLength >= length)) return (ERROR);
+  uint16_t value = 0U;
+  for (uint16_t i = prefixLength; i < length; i++) {
+    if ((command[i] < '0') || (command[i] > '9')) return (ERROR);
+    value = (uint16_t)(value * 10U + (command[i] - '0'));
+    if (value > 255U) return (ERROR);
+  }
+  if (value == 0U) return (ERROR);
+  *sensorNumber = (uint8_t)value;
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static const char* tcpCommandService_ModelName(SensorModel_TypeDef model) {
+  switch (model) {
+    case SENSOR_MODEL_DS18B20: return ("DS18B20");
+    case SENSOR_MODEL_BMP280:  return ("BMP280");
+    case SENSOR_MODEL_BME280:  return ("BME280");
+    case SENSOR_MODEL_BME680:  return ("BME680");
+    default:                   return ("unknown");
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpCommandService_AppendPressure(
+  char* response,
+  size_t capacity,
+  size_t* used,
+  uint32_t pressure
+) {
+  int written = snprintf(
+    &response[*used],
+    capacity - *used,
+    "%lu",
+    (unsigned long)pressure
+  );
+  if (written > 0) {
+    size_t remaining = capacity - *used;
+    size_t appended = (size_t)written;
+    *used += (appended < remaining) ? appended : (remaining - 1U);
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpCommandService_AppendHumidity(
+  char* response,
+  size_t capacity,
+  size_t* used,
+  uint32_t humidity
+) {
+  int written = snprintf(
+    &response[*used],
+    capacity - *used,
+    "%lu.%03lu",
+    (unsigned long)(humidity / 1000U),
+    (unsigned long)(humidity % 1000U)
+  );
+  if (written > 0) {
+    size_t remaining = capacity - *used;
+    size_t appended = (size_t)written;
+    *used += (appended < remaining) ? appended : (remaining - 1U);
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpCommandService_AppendTemperature(
+  char* response,
+  size_t capacity,
+  size_t* used,
+  int16_t centiDegrees
+) {
+  uint32_t magnitude = (centiDegrees < 0)
+    ? (uint32_t)(-(int32_t)centiDegrees)
+    : (uint32_t)centiDegrees;
+
+  int written = snprintf(
+    &response[*used],
+    capacity - *used,
+    "%s%lu.%02lu",
+    (centiDegrees < 0) ? "-" : "",
+    (unsigned long)(magnitude / 100U),
+    (unsigned long)(magnitude % 100U)
+  );
+  if (written > 0) {
+    size_t remaining = capacity - *used;
+    size_t appended = (size_t)written;
+    *used += (appended < remaining) ? appended : (remaining - 1U);
+  }
 }
 
 
@@ -238,32 +509,4 @@ static ErrorStatus tcpCommandService_Send(const char* response) {
   (void) disconnect(TCP_COMMAND_SOCKET);
   commandLength = 0U;
   return (SUCCESS);
-}
-
-
-
-
-// -------------------------------------------------------------
-static void tcpCommandService_AppendTemperature(
-  char* response,
-  size_t capacity,
-  size_t* used,
-  int16_t centiDegrees
-) {
-  uint32_t magnitude = (centiDegrees < 0)
-    ? (uint32_t)(-(int32_t)centiDegrees)
-    : (uint32_t)centiDegrees;
-
-  int written = snprintf(
-    &response[*used],
-    capacity - *used,
-    " %s%lu.%02lu",
-    (centiDegrees < 0) ? "-" : "",
-    (unsigned long)(magnitude / 100U),
-    (unsigned long)(magnitude % 100U)
-  );
-  if (written > 0) {
-    size_t appended = (size_t)written;
-    *used += (appended < (capacity - *used)) ? appended : (capacity - *used - 1U);
-  }
 }

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -41,6 +41,7 @@ static ErrorStatus tcpCommandService_ParseSensorNumber(
 static const char* tcpCommandService_ModelName(SensorModel_TypeDef);
 static const char* tcpCommandService_HealthName(SensorHealthState_TypeDef);
 static const char* tcpCommandService_ErrorName(SensorError_TypeDef);
+static void tcpCommandService_AppendText(char*, size_t, size_t*, const char*);
 static void tcpCommandService_AppendTemperature(char*, size_t, size_t*, int16_t);
 static void tcpCommandService_AppendPressure(char*, size_t, size_t*, uint32_t);
 static void tcpCommandService_AppendHumidity(char*, size_t, size_t*, uint32_t);
@@ -91,7 +92,6 @@ void TcpCommandService_Run(void) {
       if ((getSn_IR(TCP_COMMAND_SOCKET) & Sn_IR_CON) != 0U) {
         setSn_IR(TCP_COMMAND_SOCKET, Sn_IR_CON);
         commandLength = 0U;
-        printf("TCP connection\n");
       }
 
       tcpCommandService_Receive();
@@ -135,7 +135,6 @@ static void tcpHealthService_Run(void) {
       if ((getSn_IR(TCP_HEALTH_SOCKET) & Sn_IR_CON) != 0U) {
         setSn_IR(TCP_HEALTH_SOCKET, Sn_IR_CON);
         healthLength = 0U;
-        printf("Service info connection\n");
       }
       tcpHealthService_Receive();
       break;
@@ -255,11 +254,7 @@ static void tcpCommandService_ProcessInput(void) {
     commandLength = remaining;
   }
 
-  /* Also accept the complete example command without a line terminator. */
-  if ((commandLength == 8U) && (memcmp(commandBuffer, "get_tmpr", 8U) == 0)) {
-    tcpCommandService_ProcessCommand(commandBuffer, commandLength);
-    commandLength = 0U;
-  } else if (commandLength == TCP_COMMAND_BUFFER_SIZE) {
+  if (commandLength == TCP_COMMAND_BUFFER_SIZE) {
     (void) tcpCommandService_Send("ERR command_too_long\r\n");
     commandLength = 0U;
   }
@@ -304,43 +299,6 @@ static void tcpHealthService_ProcessInput(void) {
 static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t length) {
   char response[TCP_RESPONSE_SIZE];
   size_t used = 0U;
-
-  /* Preserve the original command as an alias returning all temperatures. */
-  if ((length == 8U) && (memcmp(command, "get_tmpr", 8U) == 0)) {
-    SensorCounts_TypeDef counts;
-    TemperatureSensorService_GetCounts(&counts);
-    used = (size_t)snprintf(response, sizeof(response), "OK");
-    for (uint8_t i = 1U; i <= counts.temperature; i++) {
-      SensorSnapshot_TypeDef snapshot;
-      if ((TemperatureSensorService_GetByCapability(
-             SENSOR_CAPABILITY_TEMPERATURE,
-             i,
-             &snapshot
-           ) != SUCCESS)
-          || (snapshot.dataValid != pdTRUE)) {
-        (void)tcpCommandService_Send("ERR temperature_unavailable\r\n");
-        return;
-      }
-      response[used++] = ' ';
-      tcpCommandService_AppendTemperature(
-        response,
-        sizeof(response),
-        &used,
-        snapshot.temperature
-      );
-    }
-    if (counts.temperature == 0U) {
-      (void)tcpCommandService_Send("ERR temperature_unavailable\r\n");
-      return;
-    }
-    if (used < (sizeof(response) - 2U)) {
-      response[used++] = '\r';
-      response[used++] = '\n';
-      response[used] = '\0';
-    }
-    (void)tcpCommandService_Send(response);
-    return;
-  }
 
   typedef enum {
     TCP_SENSOR_COMMAND_NONE = 0U,
@@ -414,14 +372,16 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   if ((commandType == TCP_SENSOR_COMMAND_ALL)
       || (commandType == TCP_SENSOR_COMMAND_TEMPERATURE)) {
     if (commandType == TCP_SENSOR_COMMAND_ALL) {
-      used += (size_t)snprintf(
-        &response[used],
-        sizeof(response) - used,
-        " model:%s,t:",
+      tcpCommandService_AppendText(response, sizeof(response), &used, " model:");
+      tcpCommandService_AppendText(
+        response,
+        sizeof(response),
+        &used,
         tcpCommandService_ModelName(snapshot.model)
       );
+      tcpCommandService_AppendText(response, sizeof(response), &used, ",t:");
     } else {
-      response[used++] = ' ';
+      tcpCommandService_AppendText(response, sizeof(response), &used, " ");
     }
     tcpCommandService_AppendTemperature(
       response,
@@ -432,18 +392,18 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   }
   if ((commandType == TCP_SENSOR_COMMAND_ALL)
       && ((snapshot.capabilities & SENSOR_CAPABILITY_PRESSURE) != 0U)) {
-    used += (size_t)snprintf(&response[used], sizeof(response) - used, ",p:");
+    tcpCommandService_AppendText(response, sizeof(response), &used, ",p:");
     tcpCommandService_AppendPressure(response, sizeof(response), &used, snapshot.pressure);
   } else if (commandType == TCP_SENSOR_COMMAND_PRESSURE) {
-    response[used++] = ' ';
+    tcpCommandService_AppendText(response, sizeof(response), &used, " ");
     tcpCommandService_AppendPressure(response, sizeof(response), &used, snapshot.pressure);
   }
   if ((commandType == TCP_SENSOR_COMMAND_ALL)
       && ((snapshot.capabilities & SENSOR_CAPABILITY_HUMIDITY) != 0U)) {
-    used += (size_t)snprintf(&response[used], sizeof(response) - used, ",h:");
+    tcpCommandService_AppendText(response, sizeof(response), &used, ",h:");
     tcpCommandService_AppendHumidity(response, sizeof(response), &used, snapshot.humidity);
   } else if (commandType == TCP_SENSOR_COMMAND_HUMIDITY) {
-    response[used++] = ' ';
+    tcpCommandService_AppendText(response, sizeof(response), &used, " ");
     tcpCommandService_AppendHumidity(response, sizeof(response), &used, snapshot.humidity);
   }
   if (used < (sizeof(response) - 2U)) {
@@ -658,6 +618,28 @@ static const char* tcpCommandService_ErrorName(SensorError_TypeDef error) {
     case SENSOR_ERROR_CONVERSION: return ("conversion");
     default:                      return ("unknown");
   }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void tcpCommandService_AppendText(
+  char* response,
+  size_t capacity,
+  size_t* used,
+  const char* text
+) {
+  if ((response == NULL) || (used == NULL) || (text == NULL)
+      || (*used >= capacity)) {
+    return;
+  }
+  size_t available = capacity - *used - 1U;
+  size_t length = strlen(text);
+  size_t copyLength = (length < available) ? length : available;
+  memcpy(&response[*used], text, copyLength);
+  *used += copyLength;
+  response[*used] = '\0';
 }
 
 

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -9,8 +9,11 @@
 #include "ds18b20.h"
 #include "bmx280.h"
 #include "bmx680.h"
+#include <string.h>
 
 #define TEMPERATURE_SERVICE_PERIOD_MS 7000U
+#define SENSOR_STALE_PERIOD_MS        (TEMPERATURE_SERVICE_PERIOD_MS * 3U)
+#define SENSOR_FAILURE_THRESHOLD      3U
 #define MEMORY_REPORT_CYCLES          10U
 
 static SensorSnapshot_TypeDef sensorSnapshots[SENSOR_SERVICE_MAX_DEVICES];
@@ -19,23 +22,36 @@ static BaseType_t bmx280Registered;
 static BaseType_t bmx680Registered;
 
 static void temperatureSensorService_Task(void*);
-static ErrorStatus temperatureSensorService_MeasureDs18b20(int16_t*, uint8_t*);
+static ErrorStatus temperatureSensorService_MeasureDs18b20(
+  DS18B20_Measurement_TypeDef*,
+  uint8_t*
+);
 static ErrorStatus temperatureSensorService_MeasureBmx280(void);
 static ErrorStatus temperatureSensorService_MeasureBmx680(void);
 static void temperatureSensorService_UpdateSnapshots(
-  const int16_t*,
+  const DS18B20_Measurement_TypeDef*,
   uint8_t,
-  ErrorStatus,
   ErrorStatus,
   ErrorStatus
 );
 static void temperatureSensorService_PrintMeasurements(
-  const int16_t*,
+  const DS18B20_Measurement_TypeDef*,
   uint8_t,
-  ErrorStatus,
   ErrorStatus,
   ErrorStatus
 );
+static int8_t temperatureSensorService_FindDs18b20(const uint8_t*);
+static int8_t temperatureSensorService_FindModel(SensorModel_TypeDef);
+static void temperatureSensorService_RecordResult(
+  SensorSnapshot_TypeDef*,
+  ErrorStatus,
+  SensorError_TypeDef,
+  TickType_t
+);
+static SensorError_TypeDef temperatureSensorService_MapDs18b20Error(
+  DS18B20_Status_TypeDef
+);
+static void temperatureSensorService_ApplyAge(SensorSnapshot_TypeDef*);
 static void temperatureSensorService_ReportMemory(void);
 static UBaseType_t temperatureSensorService_GetStackMargin(const char*);
 static void temperatureSensorService_PrintCentiDegrees(int32_t);
@@ -106,6 +122,7 @@ ErrorStatus TemperatureSensorService_GetSnapshot(
   taskENTER_CRITICAL();
   if (sensorNumber <= sensorSnapshotCount) {
     *snapshot = sensorSnapshots[sensorNumber - 1U];
+    temperatureSensorService_ApplyAge(snapshot);
     status = SUCCESS;
   }
   taskEXIT_CRITICAL();
@@ -131,6 +148,7 @@ ErrorStatus TemperatureSensorService_GetByCapability(
       match++;
       if (match == sensorNumber) {
         *snapshot = sensorSnapshots[i];
+        temperatureSensorService_ApplyAge(snapshot);
         status = SUCCESS;
         break;
       }
@@ -150,25 +168,25 @@ static void temperatureSensorService_Task(void* parameters) {
   uint8_t memoryReportCounter = 0U;
 
   while (1) {
-    int16_t ds18b20Temperatures[SENSOR_SERVICE_MAX_DS18B20];
+    DS18B20_Measurement_TypeDef ds18b20Measurements[
+      SENSOR_SERVICE_MAX_DS18B20
+    ];
     uint8_t ds18b20Count = 0U;
-    ErrorStatus ds18b20Status = temperatureSensorService_MeasureDs18b20(
-      ds18b20Temperatures,
+    (void)temperatureSensorService_MeasureDs18b20(
+      ds18b20Measurements,
       &ds18b20Count
     );
     ErrorStatus bmx280Status = temperatureSensorService_MeasureBmx280();
     ErrorStatus bmx680Status = temperatureSensorService_MeasureBmx680();
     temperatureSensorService_UpdateSnapshots(
-      ds18b20Temperatures,
+      ds18b20Measurements,
       ds18b20Count,
-      ds18b20Status,
       bmx280Status,
       bmx680Status
     );
     temperatureSensorService_PrintMeasurements(
-      ds18b20Temperatures,
+      ds18b20Measurements,
       ds18b20Count,
-      ds18b20Status,
       bmx280Status,
       bmx680Status
     );
@@ -187,18 +205,14 @@ static void temperatureSensorService_Task(void* parameters) {
 
 // -------------------------------------------------------------
 static ErrorStatus temperatureSensorService_MeasureDs18b20(
-  int16_t* temperatures,
+  DS18B20_Measurement_TypeDef* measurements,
   uint8_t* count
 ) {
-  if (DS18B20_MeasureTemperatures(
-        temperatures,
-        SENSOR_SERVICE_MAX_DS18B20,
-        count
-      ) != SUCCESS) {
-    return (ERROR);
-  }
-
-  return (SUCCESS);
+  return DS18B20_Measure(
+    measurements,
+    SENSOR_SERVICE_MAX_DS18B20,
+    count
+  );
 }
 
 
@@ -228,71 +242,120 @@ static ErrorStatus temperatureSensorService_MeasureBmx680(void) {
 
 // -------------------------------------------------------------
 static void temperatureSensorService_UpdateSnapshots(
-  const int16_t* ds18b20Temperatures,
+  const DS18B20_Measurement_TypeDef* ds18b20Measurements,
   uint8_t ds18b20Count,
-  ErrorStatus ds18b20Status,
   ErrorStatus bmx280Status,
   ErrorStatus bmx680Status
 ) {
-  SensorSnapshot_TypeDef updated[SENSOR_SERVICE_MAX_DEVICES];
-  uint8_t count = 0U;
-
-  if (ds18b20Status == SUCCESS) {
-    for (uint8_t i = 0U;
-         (i < ds18b20Count) && (count < SENSOR_SERVICE_MAX_DEVICES);
-         i++) {
-      updated[count++] = (SensorSnapshot_TypeDef){
-        .model = SENSOR_MODEL_DS18B20,
-        .capabilities = SENSOR_CAPABILITY_TEMPERATURE,
-        .dataValid = pdTRUE,
-        .temperature = ds18b20Temperatures[i]
-      };
-    }
-  } else {
-    taskENTER_CRITICAL();
-    while ((count < sensorSnapshotCount)
-        && (sensorSnapshots[count].model == SENSOR_MODEL_DS18B20)) {
-      updated[count] = sensorSnapshots[count];
-      updated[count].dataValid = pdFALSE;
-      count++;
-    }
-    taskEXIT_CRITICAL();
-  }
-
-  if ((bmx280Registered == pdTRUE) && (count < SENSOR_SERVICE_MAX_DEVICES)) {
-    BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
-    uint8_t capabilities = SENSOR_CAPABILITY_TEMPERATURE
-      | SENSOR_CAPABILITY_PRESSURE;
-    if (device->DevID == BME280_ID) capabilities |= SENSOR_CAPABILITY_HUMIDITY;
-    updated[count++] = (SensorSnapshot_TypeDef){
-      .model = (device->DevID == BME280_ID)
-        ? SENSOR_MODEL_BME280
-        : SENSOR_MODEL_BMP280,
-      .capabilities = capabilities,
-      .dataValid = (bmx280Status == SUCCESS) ? pdTRUE : pdFALSE,
-      .temperature = device->Results.temperature,
-      .pressure = device->Results.pressure,
-      .humidity = device->Results.humidity
-    };
-  }
-
-  if ((bmx680Registered == pdTRUE) && (count < SENSOR_SERVICE_MAX_DEVICES)) {
-    BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
-    updated[count++] = (SensorSnapshot_TypeDef){
-      .model = SENSOR_MODEL_BME680,
-      .capabilities = SENSOR_CAPABILITY_TEMPERATURE
-        | SENSOR_CAPABILITY_PRESSURE
-        | SENSOR_CAPABILITY_HUMIDITY,
-      .dataValid = (bmx680Status == SUCCESS) ? pdTRUE : pdFALSE,
-      .temperature = device->Results.temperature,
-      .pressure = device->Results.pressure,
-      .humidity = device->Results.humidity
-    };
-  }
+  TickType_t now = xTaskGetTickCount();
+  BaseType_t ds18b20Seen[SENSOR_SERVICE_MAX_DEVICES] = {pdFALSE};
 
   taskENTER_CRITICAL();
-  for (uint8_t i = 0U; i < count; i++) sensorSnapshots[i] = updated[i];
-  sensorSnapshotCount = count;
+  for (uint8_t i = 0U; i < ds18b20Count; i++) {
+    int8_t index = temperatureSensorService_FindDs18b20(
+      ds18b20Measurements[i].rom
+    );
+    if ((index < 0) && (sensorSnapshotCount < SENSOR_SERVICE_MAX_DEVICES)) {
+      index = (int8_t)sensorSnapshotCount++;
+      sensorSnapshots[index] = (SensorSnapshot_TypeDef){
+        .model = SENSOR_MODEL_DS18B20,
+        .capabilities = SENSOR_CAPABILITY_TEMPERATURE,
+        .health = SENSOR_HEALTH_INITIALIZING,
+        .lastError = SENSOR_ERROR_NOT_READY
+      };
+      memcpy(
+        sensorSnapshots[index].identity,
+        ds18b20Measurements[i].rom,
+        sizeof(sensorSnapshots[index].identity)
+      );
+    }
+    if (index >= 0) {
+      ds18b20Seen[(uint8_t)index] = pdTRUE;
+      ErrorStatus status = (ds18b20Measurements[i].status == DS18B20_STATUS_OK)
+        ? SUCCESS
+        : ERROR;
+      if (status == SUCCESS) {
+        sensorSnapshots[index].temperature = ds18b20Measurements[i].temperature;
+      }
+      temperatureSensorService_RecordResult(
+        &sensorSnapshots[index],
+        status,
+        temperatureSensorService_MapDs18b20Error(ds18b20Measurements[i].status),
+        now
+      );
+    }
+  }
+  for (uint8_t i = 0U; i < sensorSnapshotCount; i++) {
+    if ((sensorSnapshots[i].model == SENSOR_MODEL_DS18B20)
+        && (ds18b20Seen[i] == pdFALSE)) {
+      temperatureSensorService_RecordResult(
+        &sensorSnapshots[i],
+        ERROR,
+        SENSOR_ERROR_MISSING,
+        now
+      );
+      sensorSnapshots[i].health = SENSOR_HEALTH_MISSING;
+      sensorSnapshots[i].dataValid = pdFALSE;
+    }
+  }
+
+  if (bmx280Registered == pdTRUE) {
+    BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
+    int8_t index = temperatureSensorService_FindModel(
+      (device->DevID == BME280_ID) ? SENSOR_MODEL_BME280 : SENSOR_MODEL_BMP280
+    );
+    if ((index < 0) && (sensorSnapshotCount < SENSOR_SERVICE_MAX_DEVICES)) {
+      index = (int8_t)sensorSnapshotCount++;
+      sensorSnapshots[index] = (SensorSnapshot_TypeDef){
+        .model = (device->DevID == BME280_ID)
+          ? SENSOR_MODEL_BME280
+          : SENSOR_MODEL_BMP280,
+        .capabilities = SENSOR_CAPABILITY_TEMPERATURE
+          | SENSOR_CAPABILITY_PRESSURE
+          | ((device->DevID == BME280_ID) ? SENSOR_CAPABILITY_HUMIDITY : 0U),
+        .health = SENSOR_HEALTH_INITIALIZING,
+        .lastError = SENSOR_ERROR_NOT_READY
+      };
+    }
+    if (index >= 0) {
+      sensorSnapshots[index].temperature = device->Results.temperature;
+      sensorSnapshots[index].pressure = device->Results.pressure;
+      sensorSnapshots[index].humidity = device->Results.humidity;
+      temperatureSensorService_RecordResult(
+        &sensorSnapshots[index],
+        bmx280Status,
+        SENSOR_ERROR_CONVERSION,
+        now
+      );
+    }
+  }
+
+  if (bmx680Registered == pdTRUE) {
+    BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
+    int8_t index = temperatureSensorService_FindModel(SENSOR_MODEL_BME680);
+    if ((index < 0) && (sensorSnapshotCount < SENSOR_SERVICE_MAX_DEVICES)) {
+      index = (int8_t)sensorSnapshotCount++;
+      sensorSnapshots[index] = (SensorSnapshot_TypeDef){
+        .model = SENSOR_MODEL_BME680,
+        .capabilities = SENSOR_CAPABILITY_TEMPERATURE
+          | SENSOR_CAPABILITY_PRESSURE
+          | SENSOR_CAPABILITY_HUMIDITY,
+        .health = SENSOR_HEALTH_INITIALIZING,
+        .lastError = SENSOR_ERROR_NOT_READY
+      };
+    }
+    if (index >= 0) {
+      sensorSnapshots[index].temperature = device->Results.temperature;
+      sensorSnapshots[index].pressure = device->Results.pressure;
+      sensorSnapshots[index].humidity = device->Results.humidity;
+      temperatureSensorService_RecordResult(
+        &sensorSnapshots[index],
+        bmx680Status,
+        SENSOR_ERROR_CONVERSION,
+        now
+      );
+    }
+  }
   taskEXIT_CRITICAL();
 }
 
@@ -300,18 +363,110 @@ static void temperatureSensorService_UpdateSnapshots(
 
 
 // -------------------------------------------------------------
+static int8_t temperatureSensorService_FindDs18b20(const uint8_t* rom) {
+  for (uint8_t i = 0U; i < sensorSnapshotCount; i++) {
+    if ((sensorSnapshots[i].model == SENSOR_MODEL_DS18B20)
+        && (memcmp(sensorSnapshots[i].identity, rom, 8U) == 0)) {
+      return ((int8_t)i);
+    }
+  }
+  return (-1);
+}
+
+
+
+
+// -------------------------------------------------------------
+static int8_t temperatureSensorService_FindModel(SensorModel_TypeDef model) {
+  for (uint8_t i = 0U; i < sensorSnapshotCount; i++) {
+    if (sensorSnapshots[i].model == model) return ((int8_t)i);
+  }
+  return (-1);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void temperatureSensorService_RecordResult(
+  SensorSnapshot_TypeDef* snapshot,
+  ErrorStatus status,
+  SensorError_TypeDef error,
+  TickType_t now
+) {
+  snapshot->lastAttempt = now;
+  if (status == SUCCESS) {
+    snapshot->dataValid = pdTRUE;
+    snapshot->lastSuccess = now;
+    snapshot->consecutiveFailures = 0U;
+    snapshot->health = SENSOR_HEALTH_HEALTHY;
+    snapshot->lastError = SENSOR_ERROR_NONE;
+    return;
+  }
+
+  if (snapshot->consecutiveFailures < UINT16_MAX) {
+    snapshot->consecutiveFailures++;
+  }
+  snapshot->lastError = error;
+  snapshot->health = (snapshot->consecutiveFailures >= SENSOR_FAILURE_THRESHOLD)
+    ? SENSOR_HEALTH_FAILED
+    : SENSOR_HEALTH_DEGRADED;
+  if (snapshot->health == SENSOR_HEALTH_FAILED) snapshot->dataValid = pdFALSE;
+}
+
+
+
+
+// -------------------------------------------------------------
+static SensorError_TypeDef temperatureSensorService_MapDs18b20Error(
+  DS18B20_Status_TypeDef status
+) {
+  switch (status) {
+    case DS18B20_STATUS_OK:      return (SENSOR_ERROR_NONE);
+    case DS18B20_STATUS_TIMEOUT: return (SENSOR_ERROR_TIMEOUT);
+    case DS18B20_STATUS_CRC:     return (SENSOR_ERROR_CRC);
+    default:                     return (SENSOR_ERROR_BUS);
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void temperatureSensorService_ApplyAge(
+  SensorSnapshot_TypeDef* snapshot
+) {
+  if ((snapshot->lastSuccess != 0U)
+      && ((snapshot->health == SENSOR_HEALTH_HEALTHY)
+        || (snapshot->health == SENSOR_HEALTH_DEGRADED))
+      && ((xTaskGetTickCount() - snapshot->lastSuccess)
+        > pdMS_TO_TICKS(SENSOR_STALE_PERIOD_MS))) {
+    snapshot->health = SENSOR_HEALTH_STALE;
+    snapshot->dataValid = pdFALSE;
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
 static void temperatureSensorService_PrintMeasurements(
-  const int16_t* ds18b20Temperatures,
+  const DS18B20_Measurement_TypeDef* ds18b20Measurements,
   uint8_t ds18b20Count,
-  ErrorStatus ds18b20Status,
   ErrorStatus bmx280Status,
   ErrorStatus bmx680Status
 ) {
   printf("DS18B20: ");
-  if (ds18b20Status == SUCCESS) {
+  if (ds18b20Count > 0U) {
     for (uint8_t i = 0U; i < ds18b20Count; i++) {
       if (i > 0U) printf(", ");
-      temperatureSensorService_PrintCentiDegrees(ds18b20Temperatures[i]);
+      if (ds18b20Measurements[i].status == DS18B20_STATUS_OK) {
+        temperatureSensorService_PrintCentiDegrees(
+          ds18b20Measurements[i].temperature
+        );
+      } else {
+        printf("error");
+      }
     }
     printf(" C");
   } else {

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -134,34 +134,6 @@ ErrorStatus TemperatureSensorService_GetSnapshot(
 
 
 // -------------------------------------------------------------
-ErrorStatus TemperatureSensorService_GetByCapability(
-  SensorCapability_TypeDef capability,
-  uint8_t sensorNumber,
-  SensorSnapshot_TypeDef* snapshot
-) {
-  if ((sensorNumber == 0U) || (snapshot == NULL)) return (ERROR);
-  uint8_t match = 0U;
-  ErrorStatus status = ERROR;
-  taskENTER_CRITICAL();
-  for (uint8_t i = 0U; i < sensorSnapshotCount; i++) {
-    if ((sensorSnapshots[i].capabilities & capability) != 0U) {
-      match++;
-      if (match == sensorNumber) {
-        *snapshot = sensorSnapshots[i];
-        temperatureSensorService_ApplyAge(snapshot);
-        status = SUCCESS;
-        break;
-      }
-    }
-  }
-  taskEXIT_CRITICAL();
-  return (status);
-}
-
-
-
-
-// -------------------------------------------------------------
 static void temperatureSensorService_Task(void* parameters) {
   (void)parameters;
   TickType_t lastWakeTime = xTaskGetTickCount();

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -316,6 +316,7 @@ static void temperatureSensorService_UpdateSnapshots(
         .health = SENSOR_HEALTH_INITIALIZING,
         .lastError = SENSOR_ERROR_NOT_READY
       };
+      sensorSnapshots[index].serialNumber = device->UniqueID;
     }
     if (index >= 0) {
       sensorSnapshots[index].temperature = device->Results.temperature;
@@ -343,6 +344,7 @@ static void temperatureSensorService_UpdateSnapshots(
         .health = SENSOR_HEALTH_INITIALIZING,
         .lastError = SENSOR_ERROR_NOT_READY
       };
+      sensorSnapshots[index].serialNumber = device->UniqueID;
     }
     if (index >= 0) {
       sensorSnapshots[index].temperature = device->Results.temperature;

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -11,17 +11,24 @@
 #include "bmx680.h"
 
 #define TEMPERATURE_SERVICE_PERIOD_MS 7000U
-#define MAX_REPORTED_DS18B20_DEVICES  2U
 #define MEMORY_REPORT_CYCLES          10U
 
-static int16_t recentDs18b20Temperatures[MAX_REPORTED_DS18B20_DEVICES];
-static uint8_t recentDs18b20Count;
-static BaseType_t recentDs18b20Valid;
+static SensorSnapshot_TypeDef sensorSnapshots[SENSOR_SERVICE_MAX_DEVICES];
+static uint8_t sensorSnapshotCount;
+static BaseType_t bmx280Registered;
+static BaseType_t bmx680Registered;
 
 static void temperatureSensorService_Task(void*);
 static ErrorStatus temperatureSensorService_MeasureDs18b20(int16_t*, uint8_t*);
 static ErrorStatus temperatureSensorService_MeasureBmx280(void);
 static ErrorStatus temperatureSensorService_MeasureBmx680(void);
+static void temperatureSensorService_UpdateSnapshots(
+  const int16_t*,
+  uint8_t,
+  ErrorStatus,
+  ErrorStatus,
+  ErrorStatus
+);
 static void temperatureSensorService_PrintMeasurements(
   const int16_t*,
   uint8_t,
@@ -41,9 +48,13 @@ void TemperatureSensorService_Init(void) {
   if (!FLAG_CHECK(_PREG_, _PR_I2C1_BUS)) {
     if (BMx280_Init(Get_BoschDevice(BMX280_MODEL)) != SUCCESS) {
       FLAG_SET(_PREG_, _PR_BMX280);
+    } else {
+      bmx280Registered = pdTRUE;
     }
     if (BMx680_Init(Get_BoschDevice(BMX680_MODEL)) != SUCCESS) {
       FLAG_SET(_PREG_, _PR_BMX680);
+    } else {
+      bmx680Registered = pdTRUE;
     }
   } else {
     FLAG_SET(_PREG_, _PR_BMX280);
@@ -67,30 +78,66 @@ void TemperatureSensorService_Init(void) {
 
 
 // -------------------------------------------------------------
-ErrorStatus TemperatureSensorService_GetRecentDs18b20(
-  int16_t* temperatures,
-  uint8_t capacity,
-  uint8_t* count
-) {
-  if ((temperatures == NULL) || (count == NULL) || (capacity == 0U)) return (ERROR);
-  *count = 0U;
-
+void TemperatureSensorService_GetCounts(SensorCounts_TypeDef* counts) {
+  if (counts == NULL) return;
+  *counts = (SensorCounts_TypeDef){0};
   taskENTER_CRITICAL();
-  if (recentDs18b20Valid == pdFALSE) {
-    taskEXIT_CRITICAL();
-    return (ERROR);
+  counts->all = sensorSnapshotCount;
+  for (uint8_t i = 0U; i < sensorSnapshotCount; i++) {
+    uint8_t capabilities = sensorSnapshots[i].capabilities;
+    if ((capabilities & SENSOR_CAPABILITY_TEMPERATURE) != 0U) counts->temperature++;
+    if ((capabilities & SENSOR_CAPABILITY_PRESSURE) != 0U) counts->pressure++;
+    if ((capabilities & SENSOR_CAPABILITY_HUMIDITY) != 0U) counts->humidity++;
   }
-
-  uint8_t copyCount = (recentDs18b20Count < capacity)
-    ? recentDs18b20Count
-    : capacity;
-  for (uint8_t i = 0U; i < copyCount; i++) {
-    temperatures[i] = recentDs18b20Temperatures[i];
-  }
-  *count = copyCount;
   taskEXIT_CRITICAL();
+}
 
-  return (copyCount > 0U) ? SUCCESS : ERROR;
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus TemperatureSensorService_GetSnapshot(
+  uint8_t sensorNumber,
+  SensorSnapshot_TypeDef* snapshot
+) {
+  if ((sensorNumber == 0U) || (snapshot == NULL)) return (ERROR);
+  ErrorStatus status = ERROR;
+  taskENTER_CRITICAL();
+  if (sensorNumber <= sensorSnapshotCount) {
+    *snapshot = sensorSnapshots[sensorNumber - 1U];
+    status = SUCCESS;
+  }
+  taskEXIT_CRITICAL();
+  return (status);
+}
+
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus TemperatureSensorService_GetByCapability(
+  SensorCapability_TypeDef capability,
+  uint8_t sensorNumber,
+  SensorSnapshot_TypeDef* snapshot
+) {
+  if ((sensorNumber == 0U) || (snapshot == NULL)) return (ERROR);
+  uint8_t match = 0U;
+  ErrorStatus status = ERROR;
+  taskENTER_CRITICAL();
+  for (uint8_t i = 0U; i < sensorSnapshotCount; i++) {
+    if ((sensorSnapshots[i].capabilities & capability) != 0U) {
+      match++;
+      if (match == sensorNumber) {
+        *snapshot = sensorSnapshots[i];
+        status = SUCCESS;
+        break;
+      }
+    }
+  }
+  taskEXIT_CRITICAL();
+  return (status);
 }
 
 
@@ -103,7 +150,7 @@ static void temperatureSensorService_Task(void* parameters) {
   uint8_t memoryReportCounter = 0U;
 
   while (1) {
-    int16_t ds18b20Temperatures[MAX_REPORTED_DS18B20_DEVICES];
+    int16_t ds18b20Temperatures[SENSOR_SERVICE_MAX_DS18B20];
     uint8_t ds18b20Count = 0U;
     ErrorStatus ds18b20Status = temperatureSensorService_MeasureDs18b20(
       ds18b20Temperatures,
@@ -111,6 +158,13 @@ static void temperatureSensorService_Task(void* parameters) {
     );
     ErrorStatus bmx280Status = temperatureSensorService_MeasureBmx280();
     ErrorStatus bmx680Status = temperatureSensorService_MeasureBmx680();
+    temperatureSensorService_UpdateSnapshots(
+      ds18b20Temperatures,
+      ds18b20Count,
+      ds18b20Status,
+      bmx280Status,
+      bmx680Status
+    );
     temperatureSensorService_PrintMeasurements(
       ds18b20Temperatures,
       ds18b20Count,
@@ -138,19 +192,11 @@ static ErrorStatus temperatureSensorService_MeasureDs18b20(
 ) {
   if (DS18B20_MeasureTemperatures(
         temperatures,
-        MAX_REPORTED_DS18B20_DEVICES,
+        SENSOR_SERVICE_MAX_DS18B20,
         count
       ) != SUCCESS) {
     return (ERROR);
   }
-
-  taskENTER_CRITICAL();
-  for (uint8_t i = 0U; i < *count; i++) {
-    recentDs18b20Temperatures[i] = temperatures[i];
-  }
-  recentDs18b20Count = *count;
-  recentDs18b20Valid = pdTRUE;
-  taskEXIT_CRITICAL();
 
   return (SUCCESS);
 }
@@ -175,6 +221,79 @@ static ErrorStatus temperatureSensorService_MeasureBmx680(void) {
 
   BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
   return BMx680_Measurement(device);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void temperatureSensorService_UpdateSnapshots(
+  const int16_t* ds18b20Temperatures,
+  uint8_t ds18b20Count,
+  ErrorStatus ds18b20Status,
+  ErrorStatus bmx280Status,
+  ErrorStatus bmx680Status
+) {
+  SensorSnapshot_TypeDef updated[SENSOR_SERVICE_MAX_DEVICES];
+  uint8_t count = 0U;
+
+  if (ds18b20Status == SUCCESS) {
+    for (uint8_t i = 0U;
+         (i < ds18b20Count) && (count < SENSOR_SERVICE_MAX_DEVICES);
+         i++) {
+      updated[count++] = (SensorSnapshot_TypeDef){
+        .model = SENSOR_MODEL_DS18B20,
+        .capabilities = SENSOR_CAPABILITY_TEMPERATURE,
+        .dataValid = pdTRUE,
+        .temperature = ds18b20Temperatures[i]
+      };
+    }
+  } else {
+    taskENTER_CRITICAL();
+    while ((count < sensorSnapshotCount)
+        && (sensorSnapshots[count].model == SENSOR_MODEL_DS18B20)) {
+      updated[count] = sensorSnapshots[count];
+      updated[count].dataValid = pdFALSE;
+      count++;
+    }
+    taskEXIT_CRITICAL();
+  }
+
+  if ((bmx280Registered == pdTRUE) && (count < SENSOR_SERVICE_MAX_DEVICES)) {
+    BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
+    uint8_t capabilities = SENSOR_CAPABILITY_TEMPERATURE
+      | SENSOR_CAPABILITY_PRESSURE;
+    if (device->DevID == BME280_ID) capabilities |= SENSOR_CAPABILITY_HUMIDITY;
+    updated[count++] = (SensorSnapshot_TypeDef){
+      .model = (device->DevID == BME280_ID)
+        ? SENSOR_MODEL_BME280
+        : SENSOR_MODEL_BMP280,
+      .capabilities = capabilities,
+      .dataValid = (bmx280Status == SUCCESS) ? pdTRUE : pdFALSE,
+      .temperature = device->Results.temperature,
+      .pressure = device->Results.pressure,
+      .humidity = device->Results.humidity
+    };
+  }
+
+  if ((bmx680Registered == pdTRUE) && (count < SENSOR_SERVICE_MAX_DEVICES)) {
+    BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
+    updated[count++] = (SensorSnapshot_TypeDef){
+      .model = SENSOR_MODEL_BME680,
+      .capabilities = SENSOR_CAPABILITY_TEMPERATURE
+        | SENSOR_CAPABILITY_PRESSURE
+        | SENSOR_CAPABILITY_HUMIDITY,
+      .dataValid = (bmx680Status == SUCCESS) ? pdTRUE : pdFALSE,
+      .temperature = device->Results.temperature,
+      .pressure = device->Results.pressure,
+      .humidity = device->Results.humidity
+    };
+  }
+
+  taskENTER_CRITICAL();
+  for (uint8_t i = 0U; i < count; i++) sensorSnapshots[i] = updated[i];
+  sensorSnapshotCount = count;
+  taskEXIT_CRITICAL();
 }
 
 

--- a/test/sensor_tcp_test.sh
+++ b/test/sensor_tcp_test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <device-ip>" >&2
+  exit 2
+fi
+
+DEVICE_IP="$1"
+MEASUREMENT_PORT=5005
+INFO_PORT=5006
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_FILE="${SCRIPT_DIR}/sensor_tcp_test.log"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+: > "${LOG_FILE}"
+
+log() {
+  printf '%s\n' "$*" | tee -a "${LOG_FILE}"
+}
+
+request() {
+  local port="$1"
+  local command="$2"
+  printf '%s\r\n' "${command}" \
+    | nc -w 3 "${DEVICE_IP}" "${port}" 2>>"${LOG_FILE}" \
+    | tr -d '\r'
+}
+
+expect_prefix() {
+  local port="$1"
+  local command="$2"
+  local expected="$3"
+  local response
+
+  response="$(request "${port}" "${command}")"
+  if [[ "${response}" == "${expected}"* ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    log "PASS port=${port} command=${command} response=${response}"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    log "FAIL port=${port} command=${command} expected=${expected} response=${response:-<empty>}"
+  fi
+}
+
+log "Sensor TCP test"
+log "Device: ${DEVICE_IP}"
+log "Started: $(date '+%Y-%m-%d %H:%M:%S %z')"
+log ""
+
+expect_prefix "${MEASUREMENT_PORT}" "get_sensors" "ERR unknown_command"
+expect_prefix "${INFO_PORT}" "get_t_1" "ERR unknown_command"
+
+SENSOR_RESPONSE="$(request "${INFO_PORT}" "get_sensors")"
+if [[ "${SENSOR_RESPONSE}" == "OK "* ]]; then
+  PASS_COUNT=$((PASS_COUNT + 1))
+  log "PASS port=${INFO_PORT} command=get_sensors response=${SENSOR_RESPONSE}"
+else
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  log "FAIL port=${INFO_PORT} command=get_sensors expected=OK response=${SENSOR_RESPONSE:-<empty>}"
+fi
+
+SENSOR_COUNT="$(printf '%s\n' "${SENSOR_RESPONSE}" \
+  | sed -n 's/.*all:\([0-9][0-9]*\).*/\1/p')"
+
+if [ -z "${SENSOR_COUNT}" ] || [ "${SENSOR_COUNT}" -eq 0 ] 2>/dev/null; then
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  log "FAIL no registered sensors reported"
+else
+  SENSOR_NUMBER=1
+  while [ "${SENSOR_NUMBER}" -le "${SENSOR_COUNT}" ]; do
+    MODEL_RESPONSE="$(request "${INFO_PORT}" "get_model_${SENSOR_NUMBER}")"
+    MODEL="${MODEL_RESPONSE#OK }"
+
+    if [[ "${MODEL_RESPONSE}" == "OK "* ]]; then
+      PASS_COUNT=$((PASS_COUNT + 1))
+      log "PASS sensor=${SENSOR_NUMBER} model=${MODEL}"
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      log "FAIL sensor=${SENSOR_NUMBER} model_response=${MODEL_RESPONSE:-<empty>}"
+      SENSOR_NUMBER=$((SENSOR_NUMBER + 1))
+      continue
+    fi
+
+    expect_prefix "${INFO_PORT}" "get_sn_${SENSOR_NUMBER}" "OK "
+    expect_prefix "${INFO_PORT}" "health_${SENSOR_NUMBER}" "OK model:${MODEL},state:"
+    expect_prefix "${MEASUREMENT_PORT}" "get_all_${SENSOR_NUMBER}" "OK model:${MODEL},"
+    expect_prefix "${MEASUREMENT_PORT}" "get_t_${SENSOR_NUMBER}" "OK "
+
+    case "${MODEL}" in
+      DS18B20)
+        expect_prefix "${MEASUREMENT_PORT}" "get_p_${SENSOR_NUMBER}" \
+          "ERR measurement_not_supported"
+        expect_prefix "${MEASUREMENT_PORT}" "get_h_${SENSOR_NUMBER}" \
+          "ERR measurement_not_supported"
+        ;;
+      BMP280)
+        expect_prefix "${MEASUREMENT_PORT}" "get_p_${SENSOR_NUMBER}" "OK "
+        expect_prefix "${MEASUREMENT_PORT}" "get_h_${SENSOR_NUMBER}" \
+          "ERR measurement_not_supported"
+        ;;
+      BME280|BME680)
+        expect_prefix "${MEASUREMENT_PORT}" "get_p_${SENSOR_NUMBER}" "OK "
+        expect_prefix "${MEASUREMENT_PORT}" "get_h_${SENSOR_NUMBER}" "OK "
+        ;;
+      *)
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        log "FAIL sensor=${SENSOR_NUMBER} unsupported_model=${MODEL}"
+        ;;
+    esac
+
+    SENSOR_NUMBER=$((SENSOR_NUMBER + 1))
+  done
+fi
+
+expect_prefix "${MEASUREMENT_PORT}" "get_t_0" "ERR invalid_sensor_number"
+expect_prefix "${INFO_PORT}" "health_0" "ERR invalid_sensor_number"
+
+log ""
+log "Finished: $(date '+%Y-%m-%d %H:%M:%S %z')"
+log "Result: pass=${PASS_COUNT} fail=${FAIL_COUNT}"
+log "Log: ${LOG_FILE}"
+
+if [ "${FAIL_COUNT}" -ne 0 ]; then
+  exit 1
+fi

--- a/test/sensor_tcp_test.sh
+++ b/test/sensor_tcp_test.sh
@@ -51,6 +51,7 @@ log "Started: $(date '+%Y-%m-%d %H:%M:%S %z')"
 log ""
 
 expect_prefix "${MEASUREMENT_PORT}" "get_sensors" "ERR unknown_command"
+expect_prefix "${MEASUREMENT_PORT}" "get_tmpr" "ERR unknown_command"
 expect_prefix "${INFO_PORT}" "get_t_1" "ERR unknown_command"
 
 SENSOR_RESPONSE="$(request "${INFO_PORT}" "get_sensors")"


### PR DESCRIPTION
Closes #19.

Adds indexed cached sensor measurements, stable physical sensor registration, per-sensor health tracking, serial-number queries, and separate WIZnet endpoints for measurements and service information.

- Port 5005: measurement requests
- Port 5006: sensor information and health checks
- Supports up to six DS18B20 devices plus BMx280 and BME680
- Includes a Bash target smoke test and updated protocol documentation