### PR TITLE
Issue #21: add internal health supervision

### DIFF
--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -129,7 +129,8 @@
 #define IWDG_KEY_RELOAD             0x0000aaaa
 #define IWDG_KEY_ENABLE             0x0000cccc
 #define IWDG_KEY_ACCESS             0x00005555
-#define IWDG_RELOAD_COUNTER         0x00000fff /* 4095 */
+#define IWDG_PRESCALER_DIV64        0x00000004
+#define IWDG_RELOAD_COUNTER         0x000005db /* 1499 */
 
 
 

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -48,6 +48,7 @@ extern "C" {
 #include "bmx680.h"
 
 #include "heart_beat.h"
+#include "health_service.h"
 #include "temperature_service.h"
 #include "tcp_service.h"
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -79,6 +79,8 @@ int main(void) {
     TcpCommandService_Init();
   }
 
+  /* Run the internal health and watchdog service last. */
+  HealthService_Init();
 
   /* Start the scheduler. */
   vTaskStartScheduler();
@@ -95,6 +97,9 @@ int main(void) {
          * or pxCurrentTCB if pcTaskName has itself been corrupted. */
         (void) xTask;
         (void) pcTaskName;
+        system_error();
+        taskDISABLE_INTERRUPTS();
+        while (1);
     }
 
 #endif /* #if (configCHECK_FOR_STACK_OVERFLOW > 0) */
@@ -243,7 +248,5 @@ void SystemInit (void) {
       | DBGMCU_CR_DBG_WWDG_STOP
     ));
   #endif /* DEBUG */
-
-
 
 }

--- a/Srv/Inc/health_service.h
+++ b/Srv/Inc/health_service.h
@@ -1,0 +1,30 @@
+/**
+  ******************************************************************************
+  * @file           : health_service.h
+  * @brief          : Internal health supervision and watchdog service.
+  ******************************************************************************
+  */
+
+#ifndef __HEALTH_SERVICE_H
+#define __HEALTH_SERVICE_H
+
+#include "main.h"
+
+typedef enum {
+  HEALTH_COMPONENT_HEART_BEAT  = (1UL << 0U),
+  HEALTH_COMPONENT_TEMPERATURE = (1UL << 1U),
+  HEALTH_COMPONENT_TCP         = (1UL << 2U)
+} HealthComponent_TypeDef;
+
+void HealthService_Init(void);
+void HealthService_Register(HealthComponent_TypeDef);
+void HealthService_Report(HealthComponent_TypeDef);
+
+/**
+ * @brief Latch an emergency condition and stop reloading the watchdog.
+ *
+ * The IWDG resets the controller within four seconds after this call.
+ */
+void system_error(void);
+
+#endif /* __HEALTH_SERVICE_H */

--- a/Srv/Inc/health_service.h
+++ b/Srv/Inc/health_service.h
@@ -23,7 +23,8 @@ void HealthService_Report(HealthComponent_TypeDef);
 /**
  * @brief Latch an emergency condition and stop reloading the watchdog.
  *
- * The IWDG resets the controller within four seconds after this call.
+ * The IWDG timeout is nominally 2.4 seconds. The recovery target remains
+ * within four seconds after allowing for the uncalibrated LSI tolerance.
  */
 void system_error(void);
 

--- a/Srv/Src/health_service.c
+++ b/Srv/Src/health_service.c
@@ -1,0 +1,138 @@
+/**
+  ******************************************************************************
+  * @file           : health_service.c
+  * @brief          : Internal health supervision and watchdog service.
+  ******************************************************************************
+  */
+
+#include "health_service.h"
+
+#define HEALTH_CHECK_PERIOD_MS       60000U
+#define HEALTH_WATCHDOG_FEED_MS       1000U
+
+static volatile uint32_t registeredComponents;
+static volatile uint32_t reportedComponents;
+static volatile BaseType_t emergencyLatched;
+
+static void healthService_Task(void*);
+static void healthService_WatchdogInit(void);
+static void healthService_WatchdogReload(void);
+
+
+
+
+// -------------------------------------------------------------
+void HealthService_Init(void) {
+  static StaticTask_t taskControlBlock;
+  static StackType_t taskStack[configMINIMAL_STACK_SIZE];
+
+  (void)xTaskCreateStatic(
+    healthService_Task,
+    "Health",
+    configMINIMAL_STACK_SIZE,
+    NULL,
+    configMAX_PRIORITIES - 1U,
+    taskStack,
+    &taskControlBlock
+  );
+}
+
+
+
+
+// -------------------------------------------------------------
+void HealthService_Register(HealthComponent_TypeDef component) {
+  taskENTER_CRITICAL();
+  registeredComponents |= (uint32_t)component;
+  taskEXIT_CRITICAL();
+}
+
+
+
+
+// -------------------------------------------------------------
+void HealthService_Report(HealthComponent_TypeDef component) {
+  taskENTER_CRITICAL();
+  reportedComponents |= (uint32_t)component;
+  taskEXIT_CRITICAL();
+}
+
+
+
+
+// -------------------------------------------------------------
+void system_error(void) {
+  emergencyLatched = pdTRUE;
+}
+
+
+
+
+// -------------------------------------------------------------
+static void healthService_Task(void* parameters) {
+  (void)parameters;
+  TickType_t lastCheck = xTaskGetTickCount();
+  TickType_t lastFeed = lastCheck;
+
+  healthService_WatchdogInit();
+
+  while (1) {
+    TickType_t now = xTaskGetTickCount();
+
+    if (!emergencyLatched
+        && ((now - lastCheck) >= pdMS_TO_TICKS(HEALTH_CHECK_PERIOD_MS))) {
+      uint32_t expected;
+      uint32_t observed;
+
+      taskENTER_CRITICAL();
+      expected = registeredComponents;
+      observed = reportedComponents;
+      reportedComponents = 0U;
+      taskEXIT_CRITICAL();
+
+      if ((observed & expected) != expected) {
+        printf(
+          "Self-check: FAILED, missing:0x%08lx\n",
+          (unsigned long)(expected & ~observed)
+        );
+        system_error();
+      } else {
+        printf("Self-check: OK\n");
+      }
+      lastCheck = now;
+    }
+
+    if (!emergencyLatched
+        && ((now - lastFeed) >= pdMS_TO_TICKS(HEALTH_WATCHDOG_FEED_MS))) {
+      healthService_WatchdogReload();
+      lastFeed = now;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(100U));
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void healthService_WatchdogInit(void) {
+  /*
+   * Start IWDG after application initialization has completed and the
+   * scheduler is running. The nominal timeout is 2.4 seconds.
+   */
+  IWDG->KR = IWDG_KEY_ENABLE;
+  IWDG->KR = IWDG_KEY_ACCESS;
+  IWDG->PR = IWDG_PRESCALER_DIV64;
+  IWDG->RLR = IWDG_RELOAD_COUNTER;
+  while (IWDG->SR != 0U);
+  healthService_WatchdogReload();
+}
+
+
+
+
+// -------------------------------------------------------------
+static void healthService_WatchdogReload(void) {
+  IWDG->KR = IWDG_KEY_RELOAD;
+}

--- a/Srv/Src/health_service.c
+++ b/Srv/Src/health_service.c
@@ -24,12 +24,12 @@ static void healthService_WatchdogReload(void);
 // -------------------------------------------------------------
 void HealthService_Init(void) {
   static StaticTask_t taskControlBlock;
-  static StackType_t taskStack[configMINIMAL_STACK_SIZE];
+  static StackType_t taskStack[configMINIMAL_STACK_SIZE * 2U];
 
   (void)xTaskCreateStatic(
     healthService_Task,
     "Health",
-    configMINIMAL_STACK_SIZE,
+    configMINIMAL_STACK_SIZE * 2U,
     NULL,
     configMAX_PRIORITIES - 1U,
     taskStack,
@@ -119,7 +119,8 @@ static void healthService_Task(void* parameters) {
 static void healthService_WatchdogInit(void) {
   /*
    * Start IWDG after application initialization has completed and the
-   * scheduler is running. The nominal timeout is 2.4 seconds.
+   * scheduler is running. The configured timeout is 2.4 seconds at the
+   * nominal 40 kHz LSI frequency; LSI tolerance determines the actual delay.
    */
   IWDG->KR = IWDG_KEY_ENABLE;
   IWDG->KR = IWDG_KEY_ACCESS;

--- a/Srv/Src/heart_beat.c
+++ b/Srv/Src/heart_beat.c
@@ -40,6 +40,7 @@ void HeartBeatService(void) {
   static StaticTask_t heartBeatTaskTCB;
   static StackType_t heartBeatTaskStack[configMINIMAL_STACK_SIZE];
 
+  HealthService_Register(HEALTH_COMPONENT_HEART_BEAT);
   (void) xTaskCreateStatic(
                             heartBeatTask,
                             "Heart Beat",
@@ -59,6 +60,7 @@ static void heartBeatTask(void* parameters) {
 
   while(1) {
       heartBeat_Blink(HEARTBEAT_PORT, HEARTBEAT_PIN, vTaskDelay, 1200);
+      HealthService_Report(HEALTH_COMPONENT_HEART_BEAT);
   }
 }
 
@@ -80,5 +82,4 @@ static void heartBeat_Blink(GPIO_TypeDef* port, uint16_t pin, void (*callbackDel
   PIN_H(port, pin);
   callbackDelay(delay - fraction);
 }
-
 

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -54,6 +54,7 @@ void TcpCommandService_Init(void) {
   static StaticTask_t taskControlBlock;
   static StackType_t taskStack[512];
 
+  HealthService_Register(HEALTH_COMPONENT_TCP);
   (void) xTaskCreateStatic(
     tcpCommandService_Task,
     "TCP Commands",
@@ -78,6 +79,7 @@ static void tcpCommandService_Task(void* parameters) {
       tcpHealthService_Run();
       (void) SPI_Disable(SPI1);
     }
+    HealthService_Report(HEALTH_COMPONENT_TCP);
     vTaskDelay(1U);
   }
 }

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -489,13 +489,14 @@ static void temperatureSensorService_PrintMeasurements(
 // -------------------------------------------------------------
 static void temperatureSensorService_ReportMemory(void) {
   printf(
-    "Memory heap=%u min=%u stack=%u/%u/%u/%u\n",
+    "Memory heap=%u min=%u stack=%u/%u/%u/%u/%u\n",
     (unsigned int)xPortGetFreeHeapSize(),
     (unsigned int)xPortGetMinimumEverFreeHeapSize(),
     (unsigned int)temperatureSensorService_GetStackMargin("Heart Beat"),
     (unsigned int)temperatureSensorService_GetStackMargin("OW Bus Init"),
     (unsigned int)uxTaskGetStackHighWaterMark(NULL),
-    (unsigned int)temperatureSensorService_GetStackMargin("TCP Commands")
+    (unsigned int)temperatureSensorService_GetStackMargin("TCP Commands"),
+    (unsigned int)temperatureSensorService_GetStackMargin("Health")
   );
 }
 

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -79,6 +79,7 @@ void TemperatureSensorService_Init(void) {
 
   static StaticTask_t taskControlBlock;
   static StackType_t taskStack[configMINIMAL_STACK_SIZE * 4U];
+  HealthService_Register(HEALTH_COMPONENT_TEMPERATURE);
   (void)xTaskCreateStatic(
     temperatureSensorService_Task,
     "Temperature",
@@ -162,6 +163,7 @@ static void temperatureSensorService_Task(void* parameters) {
       bmx280Status,
       bmx680Status
     );
+    HealthService_Report(HEALTH_COMPONENT_TEMPERATURE);
 
     memoryReportCounter++;
     if (memoryReportCounter >= MEMORY_REPORT_CYCLES) {


### PR DESCRIPTION
Closes #21

## Summary

- add a minutely internal self-check for registered FreeRTOS services
- monitor heartbeat, temperature, and TCP task progress
- initialize and feed IWDG from the health service after application startup
- stop feeding IWDG after `system_error()` so the controller recovers within four seconds
- route stack-overflow detection into the system emergency path
- print concise successful and failed self-check results

WWDG is intentionally left disabled because the current application has no deterministic operation requiring an early/late execution window.

## Validation

Firmware builds successfully with `text 40488`, `data 292`, and `bss 17668`.