### PR TITLE
Issue #23: document and align project code

### DIFF
--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : common.h
-  * @brief          : Header for common.c file.
-  *                   This file contains the common defines of the application.
+  * @brief          : Common application definitions and low-level helper declarations.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 20.09.2025 08:34:08 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -151,19 +153,57 @@
 #define PIN_H(port, pinSource)                                  SET_PERIPH_BB_VAL((uint32_t)port, GPIO_BSRR_Offset, pinSource, 1)
 #define PIN_L(port, pinSource)                                  SET_PERIPH_BB_VAL((uint32_t)port, GPIO_BSRR_Offset, (pinSource + 16U), 1)
 // #define PIN_LEVEL(port, pinSource)                              (GET_PERIPH_BB_VAL((uint32_t)port, GPIO_IDR_Offset, pinSource))
-#define PIN_LEVEL(port, pinSource)                               (Get_BitBandVal(GET_PERIPH_BB_ADDR((uint32_t)port, GPIO_IDR_Offset, pinSource)))
+#define PIN_LEVEL(port, pinSource)                               (BitBand_GetValue(GET_PERIPH_BB_ADDR((uint32_t)port, GPIO_IDR_Offset, pinSource)))
 
 #define PREG_SET(registry, key)                                 SET_PERIPH_BB_VAL((uint32_t)&registry, 0, key, 1)
 #define PREG_CLR(registry, key)                                 SET_PERIPH_BB_VAL((uint32_t)&registry, 0, key, 0)
 // #define PREG_CHECK(registry, key)                               (GET_PERIPH_BB_VAL((uint32_t)&registry, 0, key))
-#define PREG_CHECK(registry, key)                               (Get_BitBandVal(GET_PERIPH_BB_ADDR((uint32_t)&registry, 0, key)))
+#define PREG_CHECK(registry, key)                               (BitBand_GetValue(GET_PERIPH_BB_ADDR((uint32_t)&registry, 0, key)))
 
 
 
 
 /* Exported functions prototypes ---------------------------------------------*/
-void __attribute__((weak)) Error_Handler(void);
-int __attribute__((weak)) putc_dspl(char);
+
+/**
+  * @brief Handle an unrecoverable system error.
+  *
+  * The default weak implementation stops execution. Applications may provide
+  * a strong implementation to report the failure or reset the system.
+  */
+void System_ErrorHandler(void);
+
+/**
+  * @brief Write a value through a Cortex-M3 bit-band alias address.
+  * @param aliasAddress (uint32_t) Bit-band alias address to write.
+  * @param value (uint32_t) Bit value to store; normally zero or one.
+  */
+void BitBand_SetValue(uint32_t aliasAddress, uint32_t value);
+
+/**
+  * @brief Read a value through a Cortex-M3 bit-band alias address.
+  * @param aliasAddress (uint32_t) Bit-band alias address to read.
+  * @retval (uint32_t) Current value of the aliased bit.
+  */
+uint32_t BitBand_GetValue(uint32_t aliasAddress);
+
+/**
+  * @brief Delay execution using the Cortex-M3 cycle counter.
+  * @param microseconds (uint32_t) Delay duration in microseconds.
+  *
+  * This function performs a blocking busy wait and must not be called before
+  * the core cycle counter and SystemCoreClock are initialized.
+  */
+void Delay_Microseconds(uint32_t microseconds);
+
+/**
+  * @brief Delay execution using a blocking microsecond delay.
+  * @param milliseconds (uint32_t) Delay duration in milliseconds.
+  *
+  * This function is intended for peripheral initialization and short hardware
+  * timing intervals. FreeRTOS tasks should prefer vTaskDelay for long waits.
+  */
+void Delay_Milliseconds(uint32_t milliseconds);
 
 
 

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : main.h
-  * @brief          : Header for main.c file.
-  *                   This file contains the common defines of the application.
+  * @brief          : Main application declarations and module integration.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 20.09.2025 08:34:08 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -58,41 +60,19 @@ extern "C" {
 /* Exported constants --------------------------------------------------------*/
 
 /* Exported variables --------------------------------------------------------*/
-extern __IO uint32_t _PREG_;
+extern __IO uint32_t peripheralReadiness;
 
 /* Private defines -----------------------------------------------------------*/
 /* Peripherals readiness flags */
-#define _PR_HEART_BEAT_LED    0
-#define _PR_USART1_BUS        1
-#define _PR_ONEWIRE_BUS       2
-#define _PR_SPI1_BUS          3
-#define _PR_I2C1_BUS          4
-#define _PR_WH_DISPLAY        5
-#define _PR_BMX280            6
-#define _PR_BMX680            7
-#define _PR_SSD_DISPLAY       8
-
-/* Exported functions prototypes ---------------------------------------------*/
-
-
-/* Service functions related to the CM3 BitBand */
-
-/**
- * 
- */
-extern void Set_BitBandVal(uint32_t, uint32_t);
-
-/**
- * 
- */
-extern uint32_t Get_BitBandVal(uint32_t);
-
-/**
- * 
- */
-void _delay_us(uint32_t);
-void _delay_ms(uint32_t);
-
+#define PERIPHERAL_HEARTBEAT_LED_ERROR_BIT 0
+#define PERIPHERAL_USART1_ERROR_BIT        1
+#define PERIPHERAL_ONEWIRE_ERROR_BIT       2
+#define PERIPHERAL_SPI1_ERROR_BIT          3
+#define PERIPHERAL_I2C1_ERROR_BIT          4
+#define PERIPHERAL_WH_DISPLAY_ERROR_BIT    5
+#define PERIPHERAL_BMX280_ERROR_BIT        6
+#define PERIPHERAL_BMX680_ERROR_BIT        7
+#define PERIPHERAL_SSD_DISPLAY_ERROR_BIT   8
 
 #ifdef __cplusplus
 }

--- a/Core/Inc/project_config.h
+++ b/Core/Inc/project_config.h
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : project_config.h
   * @brief          : Build-time feature selection and implementation mapping.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 04:51:32 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -21,7 +27,7 @@
 #define WH_DSPL_LINE_MODE 1
 #endif
 
-#define DSPL_OUT(ch) putc_dspl_wh(ch)
+#define DSPL_OUT(ch) WHxxxx_PutChar(ch)
 #elif defined(USE_SSD_DISPLAY)
 #ifndef SSD_DSPL_MODEL
 #define SSD_DSPL_MODEL SSD1315_MODEL
@@ -31,7 +37,7 @@
 #define SSD_DSPL_FONT SSD13XX_FONT_5X7
 #endif
 
-#define DSPL_OUT(ch) putc_dspl_ssd(ch)
+#define DSPL_OUT(ch) SSD13xx_PutChar(ch)
 #else
 #define DSPL_OUT(ch) ((void)(ch))
 #endif

--- a/Core/Src/common.c
+++ b/Core/Src/common.c
@@ -1,10 +1,13 @@
 /**
   ******************************************************************************
   * @file           : common.c
-  * @brief          : Common used routines and printf() supply
+  * @brief          : Common routines and printf output routing.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 20.09.2025 08:34:08 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -24,7 +27,7 @@ __STATIC_INLINE void _putc(uint8_t ch);
   * @param  None
   * @retval None
   */
-void __attribute__((weak)) Error_Handler(void) {
+void __attribute__((weak)) System_ErrorHandler(void) {
   while (1) {
     //
   }
@@ -71,13 +74,13 @@ __STATIC_INLINE void _putc(uint8_t ch) {
   #endif
 
   #if defined(USE_WH_DISPLAY) || defined(USE_SSD_DISPLAY)
-    if (!FLAG_CHECK(_PREG_, _PR_I2C1_BUS)
+    if (!FLAG_CHECK(peripheralReadiness, PERIPHERAL_I2C1_ERROR_BIT)
         && !FLAG_CHECK(
-          _PREG_,
+          peripheralReadiness,
           #if defined(USE_WH_DISPLAY)
-            _PR_WH_DISPLAY
+            PERIPHERAL_WH_DISPLAY_ERROR_BIT
           #else
-            _PR_SSD_DISPLAY
+            PERIPHERAL_SSD_DISPLAY_ERROR_BIT
           #endif
         )) {
       DSPL_OUT(ch);
@@ -139,7 +142,7 @@ __STATIC_INLINE void _DWT_Init(void) {
 
 
 
-void _delay_us(uint32_t us) {
+void Delay_Microseconds(uint32_t us) {
   _DWT_Init();
   uint32_t const start = DWT->CYCCNT;
   uint32_t const ticks = us * (configCPU_CLOCK_HZ / 1000000U);
@@ -149,6 +152,6 @@ void _delay_us(uint32_t us) {
 
 
 
-void _delay_ms(uint32_t ms) {
-  _delay_us(ms * 1000);
+void Delay_Milliseconds(uint32_t ms) {
+  Delay_Microseconds(ms * 1000);
 }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1,10 +1,13 @@
 /**
   ******************************************************************************
   * @file           : main.c
-  * @brief          : Main program body
+  * @brief          : Application entry point and system initialization.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 20.09.2025 08:34:08 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -12,7 +15,7 @@
 #include "main.h"
 
 /* Global variables ----------------------------------------------------------*/
-__IO uint32_t _PREG_ = 0;
+__IO uint32_t peripheralReadiness = 0;
 
 /* Private variables ---------------------------------------------------------*/
 
@@ -31,21 +34,21 @@ __IO uint32_t _PREG_ = 0;
 int main(void) {
 
   /* Initialization of necessary peripherals */
-  if (LED_Init(HEARTBEAT_PORT, HEARTBEAT_PIN) != SUCCESS) FLAG_SET(_PREG_, _PR_HEART_BEAT_LED);
-  if (OneWire_Init(OneWire_PORT, OneWire_PIN) != SUCCESS) FLAG_SET(_PREG_, _PR_ONEWIRE_BUS);
-  if (USART_Init(USART1) != SUCCESS) FLAG_SET(_PREG_, _PR_USART1_BUS);
+  if (LED_Init(HEARTBEAT_PORT, HEARTBEAT_PIN) != SUCCESS) FLAG_SET(peripheralReadiness, PERIPHERAL_HEARTBEAT_LED_ERROR_BIT);
+  if (OneWire_Init(ONEWIRE_PORT, ONEWIRE_PIN) != SUCCESS) FLAG_SET(peripheralReadiness, PERIPHERAL_ONEWIRE_ERROR_BIT);
+  if (USART_Init(USART1) != SUCCESS) FLAG_SET(peripheralReadiness, PERIPHERAL_USART1_ERROR_BIT);
   if ((SPI_Init(SPI1) != SUCCESS)
-      || (EthSPI_Init(ETH_CS_Port, ETH_CS_Pin) != SUCCESS)
-      || (EthSPI_Init(ETH_RST_Port, ETH_RST_Pin) != SUCCESS)
-      || (SPI_AdjustInit(SPI1) != SUCCESS)) {
-    FLAG_SET(_PREG_, _PR_SPI1_BUS);
+      || (EthernetSPI_Init(ETH_CS_PORT, ETH_CS_PIN) != SUCCESS)
+      || (EthernetSPI_Init(ETH_RST_PORT, ETH_RST_PIN) != SUCCESS)
+      || (SPI_AdjustConfiguration(SPI1) != SUCCESS)) {
+    FLAG_SET(peripheralReadiness, PERIPHERAL_SPI1_ERROR_BIT);
   }
   if (I2C_Init(I2C1) != SUCCESS) {
-    FLAG_SET(_PREG_, _PR_I2C1_BUS);
+    FLAG_SET(peripheralReadiness, PERIPHERAL_I2C1_ERROR_BIT);
   } else {
     #if defined(USE_WH_DISPLAY)
-      if (WHxxxx_Init(I2C1, WHxxxx_I2C_ADDR) != SUCCESS) {
-        FLAG_SET(_PREG_, _PR_WH_DISPLAY);
+      if (WHxxxx_Init(I2C1, WHXXXX_I2C_ADDRESS) != SUCCESS) {
+        FLAG_SET(peripheralReadiness, PERIPHERAL_WH_DISPLAY_ERROR_BIT);
       }
     #elif defined(USE_SSD_DISPLAY)
       static SSD13xx_TypeDef ssdDisplay;
@@ -56,26 +59,26 @@ int main(void) {
             SSD_DSPL_MODEL,
             SSD_DSPL_FONT
           ) != SUCCESS) {
-        FLAG_SET(_PREG_, _PR_SSD_DISPLAY);
+        FLAG_SET(peripheralReadiness, PERIPHERAL_SSD_DISPLAY_ERROR_BIT);
       }
     #endif
   }
 
-  if (!FLAG_CHECK(_PREG_, _PR_SPI1_BUS) && (W5500_Init() != 0)) {
-    FLAG_SET(_PREG_, _PR_SPI1_BUS);
+  if (!FLAG_CHECK(peripheralReadiness, PERIPHERAL_SPI1_ERROR_BIT) && (W5500_Init() != 0)) {
+    FLAG_SET(peripheralReadiness, PERIPHERAL_SPI1_ERROR_BIT);
   }
 
-  printf("Peripherals readiness list: 0x%08lx\n", _PREG_);
+  printf("Peripherals readiness list: 0x%08lx\n", peripheralReadiness);
   
   /* Run the Heartbeat Service */
-  HeartBeatService();
+  HeartBeatService_Init();
 
   /* Run the Temperature Measurement Service */
-  OneWireBusConfigurationInit();
+  OneWireBusConfiguration_Init();
   TemperatureSensorService_Init();
 
   /* TCP command service */
-  if (!FLAG_CHECK(_PREG_, _PR_SPI1_BUS)) {
+  if (!FLAG_CHECK(peripheralReadiness, PERIPHERAL_SPI1_ERROR_BIT)) {
     TcpCommandService_Init();
   }
 
@@ -97,7 +100,7 @@ int main(void) {
          * or pxCurrentTCB if pcTaskName has itself been corrupted. */
         (void) xTask;
         (void) pcTaskName;
-        system_error();
+        System_Error();
         taskDISABLE_INTERRUPTS();
         while (1);
     }
@@ -152,7 +155,7 @@ void SystemInit (void) {
   /* Flash */
   MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, FLASH_ACR_LATENCY_1);
   if (READ_BIT(FLASH->ACR, FLASH_ACR_LATENCY) != FLASH_ACR_LATENCY_1) {
-    Error_Handler();
+    System_ErrorHandler();
   }
 
   /* JTAG-DP disabled and SW-DP enabled */
@@ -163,13 +166,13 @@ void SystemInit (void) {
   PREG_SET(RCC->CR, RCC_CR_HSEON_Pos);
   timeout = 72000000U;
   while (!(PREG_CHECK(RCC->CR, RCC_CR_HSERDY_Pos)) && (--timeout != 0U));
-  if (timeout == 0U) Error_Handler();
+  if (timeout == 0U) System_ErrorHandler();
 
   /* LSI enable and wait until it runs */
   PREG_SET(RCC->CSR, RCC_CSR_LSION_Pos);
   timeout = 72000000U;
   while (!(PREG_CHECK(RCC->CSR, RCC_CSR_LSIRDY_Pos)) && (--timeout != 0U));
-  if (timeout == 0U) Error_Handler();
+  if (timeout == 0U) System_ErrorHandler();
 
   /* Enable backup registers access */
   PREG_SET(PWR->CR, PWR_CR_DBP_Pos);
@@ -182,7 +185,7 @@ void SystemInit (void) {
   PREG_SET(RCC->BDCR, RCC_BDCR_LSEON_Pos);
   timeout = 360000000U;
   while (!(PREG_CHECK(RCC->BDCR, RCC_BDCR_LSERDY_Pos)) && (--timeout != 0U));
-  if (timeout == 0U) Error_Handler();
+  if (timeout == 0U) System_ErrorHandler();
 
   /* RTC Source is LSE */
   MODIFY_REG(RCC->BDCR, RCC_BDCR_RTCSEL, RCC_BDCR_RTCSEL_0);
@@ -198,7 +201,7 @@ void SystemInit (void) {
   PREG_SET(RCC->CR, RCC_CR_PLLON_Pos);
   timeout = 72000000U;
   while (!(PREG_CHECK(RCC->CR, RCC_CR_PLLRDY_Pos)) && (--timeout != 0U));
-  if (timeout == 0U) Error_Handler();
+  if (timeout == 0U) System_ErrorHandler();
 
   /* AHB clock isn't divided */
   /* APB1 clock divided by 2 */
@@ -209,7 +212,7 @@ void SystemInit (void) {
   MODIFY_REG(RCC->CFGR, RCC_CFGR_SW, RCC_CFGR_SW_PLL);
   timeout = 72000000U;
   while ((READ_BIT(RCC->CFGR, RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL) && (--timeout != 0U));
-  if (timeout == 0U) Error_Handler();
+  if (timeout == 0U) System_ErrorHandler();
 
 
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -100,7 +100,7 @@ int main(void) {
          * or pxCurrentTCB if pcTaskName has itself been corrupted. */
         (void) xTask;
         (void) pcTaskName;
-        System_Error();
+        HealthService_LatchFailure();
         taskDISABLE_INTERRUPTS();
         while (1);
     }

--- a/Core/utils.s
+++ b/Core/utils.s
@@ -1,23 +1,35 @@
+/**
+  ******************************************************************************
+  * @file           : utils.s
+  * @brief          : Cortex-M3 bit-band access helper routines.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 21.09.2025 08:26:19 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
 .syntax unified
 
-.global Set_BitBandVal
-.global Get_BitBandVal
+.global BitBand_SetValue
+.global BitBand_GetValue
 
 
 
-    .section  .text.Set_BitBandVal
-    .type Set_BitBandVal, %function
-Set_BitBandVal:
+    .section  .text.BitBand_SetValue
+    .type BitBand_SetValue, %function
+BitBand_SetValue:
   str r1, [r0]
   bx lr
-  .size  Set_BitBandVal, .-Set_BitBandVal
+  .size  BitBand_SetValue, .-BitBand_SetValue
 
 
-    .section  .text.Get_BitBandVal
-    .type Get_BitBandVal, %function
-Get_BitBandVal:
+    .section  .text.BitBand_GetValue
+    .type BitBand_GetValue, %function
+BitBand_GetValue:
   ldr r0, [r0]
   bx lr
-  .size  Get_BitBandVal, .-Get_BitBandVal
-
+  .size  BitBand_GetValue, .-BitBand_GetValue
 

--- a/Ethernet/wizchip_port.c
+++ b/Ethernet/wizchip_port.c
@@ -31,10 +31,10 @@ wiz_NetInfo netInfo = {
 
 /*************************************************   NO Changes After This   ***************************************************************/
 
-#define W5500_CS_LOW()     PIN_L(ETH_CS_Port, ETH_CS_Pin);
-#define W5500_CS_HIGH()    PIN_H(ETH_CS_Port, ETH_CS_Pin);
-#define W5500_RST_LOW()    PIN_L(ETH_RST_Port, ETH_RST_Pin);
-#define W5500_RST_HIGH()   PIN_H(ETH_RST_Port, ETH_RST_Pin);
+#define W5500_CS_LOW()     PIN_L(ETH_CS_PORT, ETH_CS_PIN);
+#define W5500_CS_HIGH()    PIN_H(ETH_CS_PORT, ETH_CS_PIN);
+#define W5500_RST_LOW()    PIN_L(ETH_RST_PORT, ETH_RST_PIN);
+#define W5500_RST_HIGH()   PIN_H(ETH_RST_PORT, ETH_RST_PIN);
 
 
 // SPI transmit/receive
@@ -44,13 +44,13 @@ void W5500_Unselect(void) { W5500_CS_HIGH(); }
 uint8_t W5500_ReadByte(void)
 {
     uint8_t rx;
-    SPI_Read_8b(SPI1, &rx, 1);
+    SPI_Read8(SPI1, &rx, 1);
     return rx;
 }
 
 void W5500_WriteByte(uint8_t byte)
 {
-    SPI_Write_8b(SPI1, &byte, 1);
+    SPI_Write8(SPI1, &byte, 1);
 }
 
 
@@ -83,9 +83,9 @@ int W5500_Init(void)
     /***** Reset Sequence  *****/
     W5500_RST_LOW();
     // HAL_Delay(50);
-    _delay_ms(50);
+    Delay_Milliseconds(50);
     W5500_RST_HIGH();
-    _delay_ms(200);
+    Delay_Milliseconds(200);
     // HAL_Delay(200);
 
     /***** Register callbacks  *****/
@@ -116,7 +116,7 @@ int W5500_Init(void)
         else printf("Link: DOWN Retrying : %d\r\n", 10-retries);
         retries--;
         // HAL_Delay(500);
-        _delay_ms(500);
+        Delay_Milliseconds(500);
     }
     if (link != PHY_LINK_ON){
     	printf ("Link is Down,please reconnect and retry\nExiting Setup..\r\n");
@@ -135,7 +135,7 @@ int W5500_Init(void)
     while((!ip_assigned) && (retries > 0)) {
         DHCP_run();
         // HAL_Delay(500);
-        _delay_ms(500);
+        Delay_Milliseconds(500);
         retries--;
     }
     if(!ip_assigned) {
@@ -163,7 +163,7 @@ int W5500_Init(void)
 
     /***** Configure DNS  *****/
     // HAL_Delay(500);
-    _delay_ms(500);
+    Delay_Milliseconds(500);
     printf("Configuring DNS..\r\n");
     DNS_init(DNS_SOCKET, DNS_buffer);
 

--- a/Periph/Inc/bmx280.h
+++ b/Periph/Inc/bmx280.h
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : bmx280.h
-  * @brief          : Bosch BMP280/BME280 sensor interface.
+  * @brief          : Bosch BMP280 and BME280 sensor interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -37,6 +43,6 @@
 #define BMX280_FORCE_MODE            0x01U
 
 ErrorStatus BMx280_Init(BMxX80_TypeDef*);
-ErrorStatus BMx280_Measurement(BMxX80_TypeDef*);
+ErrorStatus BMx280_Measure(BMxX80_TypeDef*);
 
 #endif /* __BMX280_H */

--- a/Periph/Inc/bmx680.h
+++ b/Periph/Inc/bmx680.h
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : bmx680.h
   * @brief          : Bosch BME680 sensor interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -29,6 +35,6 @@
 #define BMX680_FORCED_MODE           0x01U
 
 ErrorStatus BMx680_Init(BMxX80_TypeDef*);
-ErrorStatus BMx680_Measurement(BMxX80_TypeDef*);
+ErrorStatus BMx680_Measure(BMxX80_TypeDef*);
 
 #endif /* __BMX680_H */

--- a/Periph/Inc/bmxx80.h
+++ b/Periph/Inc/bmxx80.h
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : bmxx80.h
-  * @brief          : Shared Bosch BMx280/BMx680 device definitions.
+  * @brief          : Shared Bosch BMx280 and BMx680 device definitions.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -15,17 +21,56 @@
 
 #define BMXX80_UNIQUE_ID_REG 0x83U
 
+/**
+  * @brief Compensated environmental measurements shared by Bosch sensors.
+  * @param pressure (uint32_t) Pressure in pascals.
+  * @param temperature (int32_t) Temperature in hundredths of a degree Celsius.
+  * @param humidity (uint32_t) Relative humidity in thousandths of percent.
+  * @param gasResistance (uint16_t) Raw gas-resistance result.
+  * @param gasRange (uint8_t) Gas-resistance conversion range.
+  * @param gasValid (bool) Whether the gas result is valid.
+  * @param heaterStable (bool) Whether the gas heater reached its target.
+  */
 typedef struct {
   uint32_t pressure;
   int32_t temperature;
   /* Relative humidity in thousandths of percent (100000 = 100.000 %RH). */
   uint32_t humidity;
-  uint16_t gas_resistance;
-  uint8_t gas_range;
-  bool gas_valid;
-  bool heater_stable;
-} BMxX80_results_t;
+  uint16_t gasResistance;
+  uint8_t gasRange;
+  bool gasValid;
+  bool heaterStable;
+} BMxX80_Results_TypeDef;
 
+/**
+  * @brief Factory compensation coefficients read from a BME680.
+  * @param par_t1 (uint16_t) Temperature coefficient T1.
+  * @param par_t2 (int16_t) Temperature coefficient T2.
+  * @param par_t3 (int8_t) Temperature coefficient T3.
+  * @param par_p1 (uint16_t) Pressure coefficient P1.
+  * @param par_p2 (int16_t) Pressure coefficient P2.
+  * @param par_p3 (int8_t) Pressure coefficient P3.
+  * @param par_p4 (int16_t) Pressure coefficient P4.
+  * @param par_p5 (int16_t) Pressure coefficient P5.
+  * @param par_p6 (int8_t) Pressure coefficient P6.
+  * @param par_p7 (int8_t) Pressure coefficient P7.
+  * @param par_p8 (int16_t) Pressure coefficient P8.
+  * @param par_p9 (int16_t) Pressure coefficient P9.
+  * @param par_p10 (uint8_t) Pressure coefficient P10.
+  * @param par_h1 (uint16_t) Humidity coefficient H1.
+  * @param par_h2 (uint16_t) Humidity coefficient H2.
+  * @param par_h3 (int8_t) Humidity coefficient H3.
+  * @param par_h4 (int8_t) Humidity coefficient H4.
+  * @param par_h5 (int8_t) Humidity coefficient H5.
+  * @param par_h6 (uint8_t) Humidity coefficient H6.
+  * @param par_h7 (int8_t) Humidity coefficient H7.
+  * @param par_g1 (int8_t) Gas coefficient G1.
+  * @param par_g2 (int16_t) Gas coefficient G2.
+  * @param par_g3 (int8_t) Gas coefficient G3.
+  *
+  * Member names follow the Bosch datasheet so each coefficient can be traced
+  * directly to the compensation formulas.
+  */
 typedef struct {
   uint16_t par_t1;
   int16_t par_t2;
@@ -50,8 +95,32 @@ typedef struct {
   int8_t par_g1;
   int16_t par_g2;
   int8_t par_g3;
-} BMx680_calib_t;
+} BMx680_Calibration_TypeDef;
 
+/**
+  * @brief Factory compensation coefficients read from a BMP280 or BME280.
+  * @param dig_t1 (uint16_t) Temperature coefficient T1.
+  * @param dig_t2 (int16_t) Temperature coefficient T2.
+  * @param dig_t3 (int16_t) Temperature coefficient T3.
+  * @param dig_p1 (uint16_t) Pressure coefficient P1.
+  * @param dig_p2 (int16_t) Pressure coefficient P2.
+  * @param dig_p3 (int16_t) Pressure coefficient P3.
+  * @param dig_p4 (int16_t) Pressure coefficient P4.
+  * @param dig_p5 (int16_t) Pressure coefficient P5.
+  * @param dig_p6 (int16_t) Pressure coefficient P6.
+  * @param dig_p7 (int16_t) Pressure coefficient P7.
+  * @param dig_p8 (int16_t) Pressure coefficient P8.
+  * @param dig_p9 (int16_t) Pressure coefficient P9.
+  * @param dig_h1 (uint8_t) Humidity coefficient H1.
+  * @param dig_h2 (int16_t) Humidity coefficient H2.
+  * @param dig_h3 (uint8_t) Humidity coefficient H3.
+  * @param dig_h4 (int16_t) Humidity coefficient H4.
+  * @param dig_h5 (int16_t) Humidity coefficient H5.
+  * @param dig_h6 (int8_t) Humidity coefficient H6.
+  *
+  * Member names follow the Bosch datasheet so each coefficient can be traced
+  * directly to the compensation formulas.
+  */
 typedef struct {
   uint16_t dig_t1;
   int16_t dig_t2;
@@ -71,19 +140,35 @@ typedef struct {
   int16_t dig_h4;
   int16_t dig_h5;
   int8_t dig_h6;
-} BMx280_calib_t;
+} BMx280_Calibration_TypeDef;
 
+/**
+  * @brief Runtime state shared by the BMx280 and BME680 drivers.
+  * @param deviceId (uint8_t) Chip identifier read from the device.
+  * @param uniqueId (uint32_t) Device value read from the unique-ID register.
+  * @param rawBuffer (uint8_t*) Driver-owned raw measurement buffer.
+  * @param results (BMxX80_Results_TypeDef) Latest compensated measurements.
+  * @param calibration (void*) Model-specific factory calibration coefficients.
+  * @param lock (FunctionalState) Driver lock state.
+  * @param i2c (I2C_TypeDef*) I2C peripheral used by the device.
+  * @param i2cAddress (uint8_t) Seven-bit I2C address.
+  */
 typedef struct {
-  uint8_t DevID;
-  uint32_t UniqueID;
-  uint8_t* RawBufPtr;
-  BMxX80_results_t Results;
-  void* CalibPtr;
-  FunctionalState Lock;
-  I2C_TypeDef* I2Cx;
-  uint8_t I2C_Address;
+  uint8_t deviceId;
+  uint32_t uniqueId;
+  uint8_t* rawBuffer;
+  BMxX80_Results_TypeDef results;
+  void* calibration;
+  FunctionalState lock;
+  I2C_TypeDef* i2c;
+  uint8_t i2cAddress;
 } BMxX80_TypeDef;
 
-BMxX80_TypeDef* Get_BoschDevice(uint16_t);
+/**
+  * @brief Return the statically allocated Bosch device for a model number.
+  * @param model (uint16_t) Bosch model selector, such as 280 or 680.
+  * @retval (BMxX80_TypeDef*) Device state, or NULL for an unsupported model.
+  */
+BMxX80_TypeDef* BMxX80_GetDevice(uint16_t);
 
 #endif /* __BMXX80_H */

--- a/Periph/Inc/ds18b20.h
+++ b/Periph/Inc/ds18b20.h
@@ -2,9 +2,12 @@
   ******************************************************************************
   * @file           : ds18b20.h
   * @brief          : DS18B20 temperature sensor interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 02:40:44 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -21,6 +24,9 @@
 
 
 
+/**
+  * @brief Result of communicating with one DS18B20 sensor.
+  */
 typedef enum {
   DS18B20_STATUS_OK = 0U,
   DS18B20_STATUS_BUS,
@@ -28,6 +34,12 @@ typedef enum {
   DS18B20_STATUS_CRC
 } DS18B20_Status_TypeDef;
 
+/**
+  * @brief Identity, temperature, and communication status for one DS18B20.
+  * @param rom (uint8_t[8]) Unique one-wire ROM code.
+  * @param temperature (int16_t) Temperature in hundredths of a degree Celsius.
+  * @param status (DS18B20_Status_TypeDef) Per-device measurement status.
+  */
 typedef struct {
   uint8_t rom[8];
   int16_t temperature;
@@ -36,10 +48,10 @@ typedef struct {
 
 /**
   * @brief Converts and reads every discovered DS18B20 independently.
-  * @param measurements Per-device identity, value, and status output.
-  * @param capacity Number of elements available in measurements.
-  * @param count Number of discovered devices written.
-  * @retval SUCCESS when at least one discovered device was reported.
+  * @param measurements (DS18B20_Measurement_TypeDef*) Per-device output array.
+  * @param capacity (uint8_t) Number of elements available in measurements.
+  * @param count (uint8_t*) Number of discovered devices written.
+  * @retval (ErrorStatus) SUCCESS when at least one device was reported.
   */
 ErrorStatus DS18B20_Measure(
   DS18B20_Measurement_TypeDef*,
@@ -49,13 +61,13 @@ ErrorStatus DS18B20_Measure(
 
 
 /* Private defines -----------------------------------------------------------*/
-#define AlarmSearch     0xec
-#define ConvertT        0x44
-#define WriteScratchpad 0x4e
-#define ReadScratchpad  0xbe
-#define CopyScratchpad  0x48
-#define RecallE         0xb8
-#define ReadPowerSupply 0xb4
+#define DS18B20_COMMAND_ALARM_SEARCH     0xec
+#define DS18B20_COMMAND_CONVERT_T        0x44
+#define DS18B20_COMMAND_WRITE_SCRATCHPAD 0x4e
+#define DS18B20_COMMAND_READ_SCRATCHPAD  0xbe
+#define DS18B20_COMMAND_COPY_SCRATCHPAD  0x48
+#define DS18B20_COMMAND_RECALL_EEPROM     0xb8
+#define DS18B20_COMMAND_READ_POWER_SUPPLY 0xb4
 
 
 

--- a/Periph/Inc/fonts.h
+++ b/Periph/Inc/fonts.h
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : fonts.h
   * @brief          : Bitmap font definitions for graphical displays.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 03:58:46 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 

--- a/Periph/Inc/gpio.h
+++ b/Periph/Inc/gpio.h
@@ -1,12 +1,13 @@
 /**
   ******************************************************************************
   * @file           : gpio.h
-  * @brief          : Header for gpio.c file.
-  *                   This file contains the common defines for the GPIO
-  *                   initialization functions.
+  * @brief          : GPIO initialization interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 02:40:44 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -60,7 +61,7 @@ ErrorStatus OneWire_Init(GPIO_TypeDef*, uint16_t);
   * @param  pin:  pin number (0..15)
   * @retval (int) Status of operation (0 = success)
   */
-ErrorStatus EthSPI_Init(GPIO_TypeDef*, uint16_t);
+ErrorStatus EthernetSPI_Init(GPIO_TypeDef*, uint16_t);
 
 
 #ifdef __cplusplus

--- a/Periph/Inc/i2c.h
+++ b/Periph/Inc/i2c.h
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : i2c.h
   * @brief          : I2C master-mode peripheral interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 04:51:32 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -14,10 +20,10 @@ extern "C" {
 
 #include "main.h"
 
-#define I2C1_SCL_Port GPIOB
-#define I2C1_SCL_Pin  GPIO_PIN_6
-#define I2C1_SDA_Port GPIOB
-#define I2C1_SDA_Pin  GPIO_PIN_7
+#define I2C1_SCL_PORT GPIOB
+#define I2C1_SCL_PIN  GPIO_PIN_6
+#define I2C1_SDA_PORT GPIOB
+#define I2C1_SDA_PIN  GPIO_PIN_7
 
 ErrorStatus I2C_Init(I2C_TypeDef*);
 ErrorStatus I2C_Master_Send(I2C_TypeDef*, uint8_t, const uint8_t*, uint16_t);

--- a/Periph/Inc/onewire.h
+++ b/Periph/Inc/onewire.h
@@ -1,12 +1,13 @@
 /**
   ******************************************************************************
   * @file           : onewire.h
-  * @brief          : Header for onewire.c file.
-  *                   This file contains the common defines for OneWire 
-  *                   devices.
+  * @brief          : One-wire bus and device interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 23.09.2025 04:55:12 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -22,11 +23,15 @@
 #include "main.h"
 
 
-/* Private typedef -----------------------------------------------------------*/
+/**
+  * @brief Identity and scratchpad data cached for one one-wire device.
+  * @param rom (uint8_t[8]) Unique one-wire ROM code.
+  * @param scratchpad (uint8_t[9]) Device scratchpad including its CRC byte.
+  */
 typedef struct {
-  uint8_t   addr[8];
-  uint8_t   spad[9];
-} OneWireDevice_t;
+  uint8_t rom[8];
+  uint8_t scratchpad[9];
+} OneWireDevice_TypeDef;
 
 
 /* Exported types ------------------------------------------------------------*/
@@ -37,61 +42,111 @@ typedef struct {
 
 /* Exported functions prototypes ---------------------------------------------*/
 
+/**
+  * @brief Reset the one-wire bus and detect a presence pulse.
+  * @retval (ErrorStatus) SUCCESS when at least one device responds.
+  */
 ErrorStatus OneWire_Reset(void);
 
-void OneWire_WriteByte(uint8_t);
+/**
+  * @brief Write one byte to the one-wire bus, least-significant bit first.
+  * @param value (uint8_t) Byte to transmit.
+  */
+void OneWire_WriteByte(uint8_t value);
 
+/**
+  * @brief Read one bit from the one-wire bus.
+  * @retval (uint8_t) Sampled bus level, either zero or one.
+  */
 uint8_t OneWire_ReadBit(void);
 
-void OneWire_ReadByte(uint8_t*);
+/**
+  * @brief Read one byte from the one-wire bus.
+  * @param value (uint8_t*) Destination for the received byte.
+  */
+void OneWire_ReadByte(uint8_t* value);
 
-uint8_t OneWire_CRC8(uint8_t, uint8_t);
+/**
+  * @brief Update a Dallas/Maxim CRC-8 with one byte.
+  * @param crc (uint8_t) Previous CRC value.
+  * @param value (uint8_t) Byte to include.
+  * @retval (uint8_t) Updated CRC value.
+  */
+uint8_t OneWire_CRC8(uint8_t crc, uint8_t value);
 
+/**
+  * @brief Discover devices and update the internal one-wire device table.
+  * @retval (ErrorStatus) SUCCESS when the bus search completes.
+  */
 ErrorStatus OneWire_Search(void);
 
-void OneWireBusConfigurationInit(void);
+/**
+  * @brief Create the task that refreshes one-wire discovery once per minute.
+  */
+void OneWireBusConfiguration_Init(void);
 
-BaseType_t OneWire_Lock(TickType_t);
+/**
+  * @brief Acquire exclusive access to the one-wire bus.
+  * @param timeout (TickType_t) Maximum number of scheduler ticks to wait.
+  * @retval (BaseType_t) pdTRUE when the bus lock was acquired.
+  */
+BaseType_t OneWire_Lock(TickType_t timeout);
 
+/**
+  * @brief Release exclusive access to the one-wire bus.
+  */
 void OneWire_Unlock(void);
 
+/**
+  * @brief Return the number of devices found by the latest bus search.
+  * @retval (uint8_t) Number of cached one-wire devices.
+  */
 uint8_t OneWire_GetDeviceCount(void);
 
+/**
+  * @brief Drive the one-wire pin push-pull high for parasitic power.
+  */
 void OneWire_StrongPullupEnable(void);
 
+/**
+  * @brief Release parasitic power and restore open-drain one-wire operation.
+  */
 void OneWire_StrongPullupDisable(void);
 
 /**
- * @brief   Defines parasitic powered devices on OnWire bus.
- * @param   addr pointer to OneWire device address
- * @retval  (uint8_t) status of power supply
- */
-uint8_t OneWire_ReadPowerSupply(uint8_t*);
+  * @brief Determine whether a device uses parasitic power.
+  * @param rom (uint8_t*) Eight-byte one-wire ROM code.
+  * @retval (uint8_t) Zero for parasitic power and one for external power.
+  */
+uint8_t OneWire_ReadPowerSupply(uint8_t* rom);
 
 /**
- * @brief   Determines the existent of the device with given address, on the bus.
- * @param   addr pointer to OneWire device address
- * @retval  (uint8_t) status of operation
- */
-ErrorStatus OneWire_MatchROM(uint8_t*);
+  * @brief Select the device with the supplied ROM code.
+  * @param rom (uint8_t*) Eight-byte one-wire ROM code.
+  * @retval (ErrorStatus) SUCCESS when the device acknowledges the selection.
+  */
+ErrorStatus OneWire_MatchROM(uint8_t* rom);
 
-
-OneWireDevice_t* Get_OwDevices(void);
+/**
+  * @brief Return the internal table populated by the latest bus search.
+  * @retval (OneWireDevice_TypeDef*) Borrowed pointer to the device table.
+  */
+OneWireDevice_TypeDef* OneWire_GetDevices(void);
 
 
 /* Exported defines -----------------------------------------------------------*/
-#define SearchROM       0xf0
-#define ReadROM         0x33
-#define MatchROM        0x55
-#define SkipROM         0xcc
-#define ReadPowerSupply 0xb4
+#define ONEWIRE_COMMAND_SEARCH_ROM        0xf0
+#define ONEWIRE_COMMAND_READ_ROM          0x33
+#define ONEWIRE_COMMAND_MATCH_ROM         0x55
+#define ONEWIRE_COMMAND_SKIP_ROM          0xcc
+#define ONEWIRE_COMMAND_READ_POWER_SUPPLY 0xb4
 
-#define OneWire_PORT    GPIOB
-#define OneWire_PIN     GPIO_PIN_9_Pos
+#define ONEWIRE_PORT GPIOB
+#define ONEWIRE_PIN  GPIO_PIN_9_Pos
 
-#define OneWire_Low     PIN_H(OneWire_PORT, OneWire_PIN)
-#define OneWire_High    PIN_L(OneWire_PORT, OneWire_PIN)
-#define OneWire_Level   (PIN_LEVEL(OneWire_PORT, OneWire_PIN))
+#define ONEWIRE_DRIVE_LOW PIN_H(ONEWIRE_PORT, ONEWIRE_PIN)
+#define ONEWIRE_RELEASE   PIN_L(ONEWIRE_PORT, ONEWIRE_PIN)
+#define ONEWIRE_LEVEL     (PIN_LEVEL(ONEWIRE_PORT, ONEWIRE_PIN))
 
 
 

--- a/Periph/Inc/spi.h
+++ b/Periph/Inc/spi.h
@@ -1,12 +1,13 @@
 /**
   ******************************************************************************
   * @file           : spi.h
-  * @brief          : Header for spi.c file.
-  *                   This file contains the common defines for the SPI
-  *                   initialization functions.
+  * @brief          : SPI peripheral interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 12:54:49 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -22,24 +23,24 @@
 #include "main.h"
 
 
-#define SPI1_SCK_Pin          GPIO_PIN_5
-#define SPI1_MISO_Pin         GPIO_PIN_6
-#define SPI1_MOSI_Pin         GPIO_PIN_7
-#define SPI1_Port             GPIOA
+#define SPI1_SCK_PIN          GPIO_PIN_5
+#define SPI1_MISO_PIN         GPIO_PIN_6
+#define SPI1_MOSI_PIN         GPIO_PIN_7
+#define SPI1_PORT             GPIOA
 
-#define ETH_CS_Port           GPIOA
-#define ETH_CS_Pin            GPIO_PIN_4
-#define ETH_RST_Port          GPIOA
-#define ETH_RST_Pin           GPIO_PIN_3
-#define ETH_INT_Port          GPIOA
-#define ETH_INT_Pin           GPIO_PIN_1
+#define ETH_CS_PORT           GPIOA
+#define ETH_CS_PIN            GPIO_PIN_4
+#define ETH_RST_PORT          GPIOA
+#define ETH_RST_PIN           GPIO_PIN_3
+#define ETH_INT_PORT          GPIOA
+#define ETH_INT_PIN           GPIO_PIN_1
 
-#define SPI2_SCK_Pin          GPIO_PIN_13
-#define SPI2_MISO_Pin         GPIO_PIN_14
-#define SPI2_MOSI_Pin         GPIO_PIN_15
-#define SPI2_Port             GPIOB
+#define SPI2_SCK_PIN          GPIO_PIN_13
+#define SPI2_MISO_PIN         GPIO_PIN_14
+#define SPI2_MOSI_PIN         GPIO_PIN_15
+#define SPI2_PORT             GPIOB
 
-#define SPI_BUS_TMOUT         10000 /* cycles timeout on SPI bus operations */
+#define SPI_BUS_TIMEOUT         10000 /* cycles timeout on SPI bus operations */
 
 
 
@@ -56,39 +57,39 @@
   */
 ErrorStatus SPI_Init(SPI_TypeDef*);
 
-ErrorStatus SPI_AdjustInit(SPI_TypeDef*);
+ErrorStatus SPI_AdjustConfiguration(SPI_TypeDef*);
 
 /**
  * @brief  Enables the given SPI peripherals.
- * @param  SPIx: pointer to the given SPI peripherals
+ * @param  spi: pointer to the given SPI peripherals
  * @retval status of operation
  */
 ErrorStatus SPI_Enable(SPI_TypeDef*);
 
 /**
  * @brief  Disables the given SPI peripherals.
- * @param  SPIx: pointer to the given SPI peripherals
+ * @param  spi: pointer to the given SPI peripherals
  * @retval status of operation
  */
 ErrorStatus SPI_Disable(SPI_TypeDef*);
 
 /**
   * @brief  Reads data from SPI bus with 8-bit data buffer size.
-  * @param  SPIx: pointer to the dedicatred SPI bus structure
-  * @param  buf: pointer to the buffer to store the read data
-  * @param  cnt: count of bytes to read from the bus
+  * @param  spi: pointer to the dedicatred SPI bus structure
+  * @param  buffer: pointer to the buffer to store the read data
+  * @param  length: count of bytes to read from the bus
   * @retval status of aperation
   */
-ErrorStatus SPI_Read_8b(SPI_TypeDef*, uint8_t*, uint16_t);
+ErrorStatus SPI_Read8(SPI_TypeDef*, uint8_t*, uint16_t);
 
 /**
   * @brief  Writes data to the SPI bus with 8-bit data buffer size.
-  * @param  SPIx: pointer to the dedicatred SPI bus structure
-  * @param  buf: pointer to the buffer of transmitting data
-  * @param  cnt: count of bytes to write to the bus
+  * @param  spi: pointer to the dedicatred SPI bus structure
+  * @param  buffer: pointer to the buffer of transmitting data
+  * @param  length: count of bytes to write to the bus
   * @retval status of aperation
   */
-ErrorStatus SPI_Write_8b(SPI_TypeDef*, uint8_t*, uint16_t);
+ErrorStatus SPI_Write8(SPI_TypeDef*, uint8_t*, uint16_t);
 
 
 

--- a/Periph/Inc/ssd13xx.h
+++ b/Periph/Inc/ssd13xx.h
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : ssd13xx.h
-  * @brief          : SSD1306/SSD1315 display interface over I2C.
+  * @brief          : SSD1306 and SSD1315 display interface over I2C.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 03:58:46 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -21,27 +27,58 @@ extern "C" {
 #define SSD13XX_WIDTH    128U
 #define SSD13XX_HEIGHT   64U
 
+/**
+  * @brief Fonts supported by the SSD13xx text renderer.
+  */
 typedef enum {
   SSD13XX_FONT_5X7 = 57U,
   SSD13XX_FONT_10X14 = 1014U
 } SSD13xx_Font_TypeDef;
 
+/**
+  * @brief Runtime configuration and output state for one SSD13xx display.
+  * @param i2c (I2C_TypeDef*) I2C peripheral connected to the display.
+  * @param address (uint8_t) Seven-bit I2C address.
+  * @param model (uint16_t) SSD controller model number.
+  * @param font (SSD13xx_Font_TypeDef) Active text font.
+  */
 typedef struct {
-  I2C_TypeDef* I2C;
-  uint8_t Address;
-  uint16_t Model;
-  SSD13xx_Font_TypeDef Font;
+  I2C_TypeDef* i2c;
+  uint8_t address;
+  uint16_t model;
+  SSD13xx_Font_TypeDef font;
 } SSD13xx_TypeDef;
 
+/**
+  * @brief Initialize an SSD1306 or SSD1315 display.
+  * @param display (SSD13xx_TypeDef*) State object to initialize.
+  * @param i2c (I2C_TypeDef*) I2C peripheral connected to the display.
+  * @param address (uint8_t) Seven-bit I2C address.
+  * @param model (uint16_t) Supported SSD controller model number.
+  * @param font (SSD13xx_Font_TypeDef) Initial text font.
+  * @retval (ErrorStatus) SUCCESS when initialization completes.
+  */
 ErrorStatus SSD13xx_Init(
-  SSD13xx_TypeDef*,
-  I2C_TypeDef*,
-  uint8_t,
-  uint16_t,
-  SSD13xx_Font_TypeDef
+  SSD13xx_TypeDef* display,
+  I2C_TypeDef* i2c,
+  uint8_t address,
+  uint16_t model,
+  SSD13xx_Font_TypeDef font
 );
-ErrorStatus SSD13xx_Clear(SSD13xx_TypeDef*);
-int putc_dspl_ssd(char);
+
+/**
+  * @brief Clear the display framebuffer and reset the text cursor.
+  * @param display (SSD13xx_TypeDef*) Initialized display state.
+  * @retval (ErrorStatus) SUCCESS when the display accepts the update.
+  */
+ErrorStatus SSD13xx_Clear(SSD13xx_TypeDef* display);
+
+/**
+  * @brief Append one character to the active SSD13xx text output.
+  * @param character (char) Character to append.
+  * @retval (int) The supplied character.
+  */
+int SSD13xx_PutChar(char character);
 
 #ifdef __cplusplus
 }

--- a/Periph/Inc/usart.h
+++ b/Periph/Inc/usart.h
@@ -1,12 +1,13 @@
 /**
   ******************************************************************************
   * @file           : usart.h
-  * @brief          : Header for usart.c file.
-  *                   This file contains the common defines for the USART
-  *                   initialization functions.
+  * @brief          : USART peripheral interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 02:40:44 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  

--- a/Periph/Inc/whxxxx.h
+++ b/Periph/Inc/whxxxx.h
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : whxxxx.h
   * @brief          : WHxxxx character display interface over I2C.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 04:51:32 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -14,12 +20,12 @@ extern "C" {
 
 #include "main.h"
 
-#define WHxxxx_I2C_ADDR 0x27U
+#define WHXXXX_I2C_ADDRESS 0x27U
 
 ErrorStatus WHxxxx_Init(I2C_TypeDef*, uint8_t);
 ErrorStatus WHxxxx_Clear(void);
 ErrorStatus WHxxxx_Print(const uint8_t*, uint16_t);
-int putc_dspl_wh(char);
+int WHxxxx_PutChar(char);
 
 #ifdef __cplusplus
 }

--- a/Periph/Src/bmx280.c
+++ b/Periph/Src/bmx280.c
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : bmx280.c
-  * @brief          : Bosch BMP280/BME280 sensor implementation.
+  * @brief          : Bosch BMP280 and BME280 sensor implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -24,57 +30,57 @@ static uint32_t bmx280_CompensateHumidity(BMxX80_TypeDef*);
 
 // -------------------------------------------------------------
 ErrorStatus BMx280_Init(BMxX80_TypeDef* dev) {
-  if ((dev == NULL) || (dev->I2Cx == NULL) || (dev->RawBufPtr == NULL)
-      || (dev->CalibPtr == NULL) || (dev->Lock != DISABLE)) {
+  if ((dev == NULL) || (dev->i2c == NULL) || (dev->rawBuffer == NULL)
+      || (dev->calibration == NULL) || (dev->lock != DISABLE)) {
     return (ERROR);
   }
-  dev->Lock = ENABLE;
+  dev->lock = ENABLE;
   ErrorStatus status = ERROR;
 
   if (bmx280_Receive(dev, BMX280_DEV_ID, 1U) != SUCCESS) goto done;
-  dev->DevID = dev->RawBufPtr[0];
-  if ((dev->DevID != BMP280_ID) && (dev->DevID != BME280_ID)) goto done;
+  dev->deviceId = dev->rawBuffer[0];
+  if ((dev->deviceId != BMP280_ID) && (dev->deviceId != BME280_ID)) goto done;
   if (bmx280_Receive(dev, BMXX80_UNIQUE_ID_REG, 4U) != SUCCESS) goto done;
-  dev->UniqueID = (
-      ((((uint32_t)dev->RawBufPtr[3]
-        + ((uint32_t)dev->RawBufPtr[2] << 8)) & 0x7FFFU) << 16)
-    | ((uint32_t)dev->RawBufPtr[1] << 8)
-    | (uint32_t)dev->RawBufPtr[0]
+  dev->uniqueId = (
+      ((((uint32_t)dev->rawBuffer[3]
+        + ((uint32_t)dev->rawBuffer[2] << 8)) & 0x7FFFU) << 16)
+    | ((uint32_t)dev->rawBuffer[1] << 8)
+    | (uint32_t)dev->rawBuffer[0]
   );
 
   if (bmx280_Send(dev, BMX280_RESET, BMX280_RESET_VALUE) != SUCCESS) goto done;
   if (bmx280_WaitNvmCopy(dev) != SUCCESS) goto done;
 
   if (bmx280_Receive(dev, BMX280_CALIB1, 26U) != SUCCESS) goto done;
-  BMx280_calib_t* calib = (BMx280_calib_t*)dev->CalibPtr;
-  calib->dig_t1 = (uint16_t)((dev->RawBufPtr[1] << 8) | dev->RawBufPtr[0]);
-  calib->dig_t2 = (int16_t)((dev->RawBufPtr[3] << 8) | dev->RawBufPtr[2]);
-  calib->dig_t3 = (int16_t)((dev->RawBufPtr[5] << 8) | dev->RawBufPtr[4]);
-  calib->dig_p1 = (uint16_t)((dev->RawBufPtr[7] << 8) | dev->RawBufPtr[6]);
-  calib->dig_p2 = (int16_t)((dev->RawBufPtr[9] << 8) | dev->RawBufPtr[8]);
-  calib->dig_p3 = (int16_t)((dev->RawBufPtr[11] << 8) | dev->RawBufPtr[10]);
-  calib->dig_p4 = (int16_t)((dev->RawBufPtr[13] << 8) | dev->RawBufPtr[12]);
-  calib->dig_p5 = (int16_t)((dev->RawBufPtr[15] << 8) | dev->RawBufPtr[14]);
-  calib->dig_p6 = (int16_t)((dev->RawBufPtr[17] << 8) | dev->RawBufPtr[16]);
-  calib->dig_p7 = (int16_t)((dev->RawBufPtr[19] << 8) | dev->RawBufPtr[18]);
-  calib->dig_p8 = (int16_t)((dev->RawBufPtr[21] << 8) | dev->RawBufPtr[20]);
-  calib->dig_p9 = (int16_t)((dev->RawBufPtr[23] << 8) | dev->RawBufPtr[22]);
+  BMx280_Calibration_TypeDef* calib = (BMx280_Calibration_TypeDef*)dev->calibration;
+  calib->dig_t1 = (uint16_t)((dev->rawBuffer[1] << 8) | dev->rawBuffer[0]);
+  calib->dig_t2 = (int16_t)((dev->rawBuffer[3] << 8) | dev->rawBuffer[2]);
+  calib->dig_t3 = (int16_t)((dev->rawBuffer[5] << 8) | dev->rawBuffer[4]);
+  calib->dig_p1 = (uint16_t)((dev->rawBuffer[7] << 8) | dev->rawBuffer[6]);
+  calib->dig_p2 = (int16_t)((dev->rawBuffer[9] << 8) | dev->rawBuffer[8]);
+  calib->dig_p3 = (int16_t)((dev->rawBuffer[11] << 8) | dev->rawBuffer[10]);
+  calib->dig_p4 = (int16_t)((dev->rawBuffer[13] << 8) | dev->rawBuffer[12]);
+  calib->dig_p5 = (int16_t)((dev->rawBuffer[15] << 8) | dev->rawBuffer[14]);
+  calib->dig_p6 = (int16_t)((dev->rawBuffer[17] << 8) | dev->rawBuffer[16]);
+  calib->dig_p7 = (int16_t)((dev->rawBuffer[19] << 8) | dev->rawBuffer[18]);
+  calib->dig_p8 = (int16_t)((dev->rawBuffer[21] << 8) | dev->rawBuffer[20]);
+  calib->dig_p9 = (int16_t)((dev->rawBuffer[23] << 8) | dev->rawBuffer[22]);
   if (calib->dig_p1 == 0U) goto done;
 
-  if (dev->DevID == BME280_ID) {
-    calib->dig_h1 = dev->RawBufPtr[25];
+  if (dev->deviceId == BME280_ID) {
+    calib->dig_h1 = dev->rawBuffer[25];
     if (bmx280_Receive(dev, BMX280_CALIB2, 7U) != SUCCESS) goto done;
-    calib->dig_h2 = (int16_t)((dev->RawBufPtr[1] << 8) | dev->RawBufPtr[0]);
-    calib->dig_h3 = dev->RawBufPtr[2];
+    calib->dig_h2 = (int16_t)((dev->rawBuffer[1] << 8) | dev->rawBuffer[0]);
+    calib->dig_h3 = dev->rawBuffer[2];
     calib->dig_h4 = (int16_t)(
-      ((int16_t)(int8_t)dev->RawBufPtr[3] * 16)
-      | (dev->RawBufPtr[4] & 0x0FU)
+      ((int16_t)(int8_t)dev->rawBuffer[3] * 16)
+      | (dev->rawBuffer[4] & 0x0FU)
     );
     calib->dig_h5 = (int16_t)(
-      ((int16_t)(int8_t)dev->RawBufPtr[5] * 16)
-      | (dev->RawBufPtr[4] >> 4)
+      ((int16_t)(int8_t)dev->rawBuffer[5] * 16)
+      | (dev->rawBuffer[4] >> 4)
     );
-    calib->dig_h6 = (int8_t)dev->RawBufPtr[6];
+    calib->dig_h6 = (int8_t)dev->rawBuffer[6];
   }
 
   if (bmx280_Send(
@@ -82,7 +88,7 @@ ErrorStatus BMx280_Init(BMxX80_TypeDef* dev) {
         BMX280_SETTINGS,
         BMX280_CONFIG_INACTIVE_250 | BMX280_CONFIG_FILTER_4
       ) != SUCCESS) goto done;
-  if ((dev->DevID == BME280_ID)
+  if ((dev->deviceId == BME280_ID)
       && (bmx280_Send(dev, BMX280_CTRL_HUM, BMX280_HUMIDITY_OVS_X4) != SUCCESS)) {
     goto done;
   }
@@ -95,7 +101,7 @@ ErrorStatus BMx280_Init(BMxX80_TypeDef* dev) {
   status = SUCCESS;
 
 done:
-  dev->Lock = DISABLE;
+  dev->lock = DISABLE;
   return (status);
 }
 
@@ -103,9 +109,9 @@ done:
 
 
 // -------------------------------------------------------------
-ErrorStatus BMx280_Measurement(BMxX80_TypeDef* dev) {
-  if ((dev == NULL) || (dev->Lock != DISABLE)) return (ERROR);
-  dev->Lock = ENABLE;
+ErrorStatus BMx280_Measure(BMxX80_TypeDef* dev) {
+  if ((dev == NULL) || (dev->lock != DISABLE)) return (ERROR);
+  dev->lock = ENABLE;
   ErrorStatus status = ERROR;
 
   if (bmx280_Send(
@@ -116,33 +122,33 @@ ErrorStatus BMx280_Measurement(BMxX80_TypeDef* dev) {
 
   if (bmx280_WaitMeasurement(dev) != SUCCESS) goto done;
 
-  uint8_t dataLength = (dev->DevID == BME280_ID) ? 8U : 6U;
+  uint8_t dataLength = (dev->deviceId == BME280_ID) ? 8U : 6U;
   if (bmx280_Receive(dev, BMX280_DATA, dataLength) != SUCCESS) goto done;
   uint32_t rawPressure = (
-      ((uint32_t)dev->RawBufPtr[0] << 12)
-    | ((uint32_t)dev->RawBufPtr[1] << 4)
-    | ((uint32_t)dev->RawBufPtr[2] >> 4)
+      ((uint32_t)dev->rawBuffer[0] << 12)
+    | ((uint32_t)dev->rawBuffer[1] << 4)
+    | ((uint32_t)dev->rawBuffer[2] >> 4)
   );
   uint32_t rawTemperature = (
-      ((uint32_t)dev->RawBufPtr[3] << 12)
-    | ((uint32_t)dev->RawBufPtr[4] << 4)
-    | ((uint32_t)dev->RawBufPtr[5] >> 4)
+      ((uint32_t)dev->rawBuffer[3] << 12)
+    | ((uint32_t)dev->rawBuffer[4] << 4)
+    | ((uint32_t)dev->rawBuffer[5] >> 4)
   );
   if ((rawPressure == 0x80000U) || (rawTemperature == 0x80000U)) goto done;
 
-  dev->Results.temperature = bmx280_CompensateTemperature(dev);
-  dev->Results.pressure = bmx280_CompensatePressure(dev);
-  if (dev->DevID == BME280_ID) {
+  dev->results.temperature = bmx280_CompensateTemperature(dev);
+  dev->results.pressure = bmx280_CompensatePressure(dev);
+  if (dev->deviceId == BME280_ID) {
     uint32_t humidityQ22_10 = bmx280_CompensateHumidity(dev);
-    dev->Results.humidity = ((humidityQ22_10 * 1000U) + 512U) / 1024U;
+    dev->results.humidity = ((humidityQ22_10 * 1000U) + 512U) / 1024U;
   } else {
-    dev->Results.humidity = 0U;
+    dev->results.humidity = 0U;
   }
 
   status = SUCCESS;
 
 done:
-  dev->Lock = DISABLE;
+  dev->lock = DISABLE;
   return (status);
 }
 
@@ -152,7 +158,7 @@ done:
 // -------------------------------------------------------------
 static ErrorStatus bmx280_Send(BMxX80_TypeDef* dev, uint8_t reg, uint8_t value) {
   uint8_t buffer[2] = {reg, value};
-  return I2C_Master_Send(dev->I2Cx, dev->I2C_Address, buffer, sizeof(buffer));
+  return I2C_Master_Send(dev->i2c, dev->i2cAddress, buffer, sizeof(buffer));
 }
 
 
@@ -161,10 +167,10 @@ static ErrorStatus bmx280_Send(BMxX80_TypeDef* dev, uint8_t reg, uint8_t value) 
 // -------------------------------------------------------------
 static ErrorStatus bmx280_Receive(BMxX80_TypeDef* dev, uint8_t reg, uint8_t length) {
   return I2C_Master_ReadRegister(
-    dev->I2Cx,
-    dev->I2C_Address,
+    dev->i2c,
+    dev->i2cAddress,
     reg,
-    dev->RawBufPtr,
+    dev->rawBuffer,
     length
   );
 }
@@ -175,9 +181,9 @@ static ErrorStatus bmx280_Receive(BMxX80_TypeDef* dev, uint8_t reg, uint8_t leng
 // -------------------------------------------------------------
 static ErrorStatus bmx280_WaitNvmCopy(BMxX80_TypeDef* dev) {
   for (uint8_t attempts = 0U; attempts < 5U; attempts++) {
-    _delay_ms(2U);
+    Delay_Milliseconds(2U);
     if (bmx280_Receive(dev, BMX280_STATUS, 1U) != SUCCESS) return (ERROR);
-    if ((dev->RawBufPtr[0] & BMX280_IM_UPDATE) == 0U) return (SUCCESS);
+    if ((dev->rawBuffer[0] & BMX280_IM_UPDATE) == 0U) return (SUCCESS);
   }
   return (ERROR);
 }
@@ -188,9 +194,9 @@ static ErrorStatus bmx280_WaitNvmCopy(BMxX80_TypeDef* dev) {
 // -------------------------------------------------------------
 static ErrorStatus bmx280_WaitMeasurement(BMxX80_TypeDef* dev) {
   for (uint16_t attempts = 0U; attempts < 250U; attempts++) {
-    _delay_ms(1U);
+    Delay_Milliseconds(1U);
     if (bmx280_Receive(dev, BMX280_STATUS, 1U) != SUCCESS) return (ERROR);
-    if ((dev->RawBufPtr[0] & BMX280_MEASURING) == 0U) return (SUCCESS);
+    if ((dev->rawBuffer[0] & BMX280_MEASURING) == 0U) return (SUCCESS);
   }
   return (ERROR);
 }
@@ -201,11 +207,11 @@ static ErrorStatus bmx280_WaitMeasurement(BMxX80_TypeDef* dev) {
 // -------------------------------------------------------------
 static int32_t bmx280_CompensateTemperature(BMxX80_TypeDef* dev) {
   int32_t adcTemperature = (
-      ((int32_t)dev->RawBufPtr[3] << 12)
-    | ((int32_t)dev->RawBufPtr[4] << 4)
-    | ((int32_t)dev->RawBufPtr[5] >> 4)
+      ((int32_t)dev->rawBuffer[3] << 12)
+    | ((int32_t)dev->rawBuffer[4] << 4)
+    | ((int32_t)dev->rawBuffer[5] >> 4)
   );
-  BMx280_calib_t* calib = (BMx280_calib_t*)dev->CalibPtr;
+  BMx280_Calibration_TypeDef* calib = (BMx280_Calibration_TypeDef*)dev->calibration;
   int32_t var1 = ((((adcTemperature >> 3) - ((int32_t)calib->dig_t1 << 1)))
                   * (int32_t)calib->dig_t2) >> 11;
   int32_t var2 = (((((adcTemperature >> 4) - (int32_t)calib->dig_t1)
@@ -221,11 +227,11 @@ static int32_t bmx280_CompensateTemperature(BMxX80_TypeDef* dev) {
 // -------------------------------------------------------------
 static uint32_t bmx280_CompensatePressure(BMxX80_TypeDef* dev) {
   int32_t adcPressure = (
-      ((int32_t)dev->RawBufPtr[0] << 12)
-    | ((int32_t)dev->RawBufPtr[1] << 4)
-    | ((int32_t)dev->RawBufPtr[2] >> 4)
+      ((int32_t)dev->rawBuffer[0] << 12)
+    | ((int32_t)dev->rawBuffer[1] << 4)
+    | ((int32_t)dev->rawBuffer[2] >> 4)
   );
-  BMx280_calib_t* calib = (BMx280_calib_t*)dev->CalibPtr;
+  BMx280_Calibration_TypeDef* calib = (BMx280_Calibration_TypeDef*)dev->calibration;
   int32_t var1 = (tFine >> 1) - 64000;
   int32_t var2 = (((var1 >> 2) * (var1 >> 2)) >> 11) * calib->dig_p6;
   var2 += (var1 * calib->dig_p5) << 1;
@@ -249,8 +255,8 @@ static uint32_t bmx280_CompensatePressure(BMxX80_TypeDef* dev) {
 
 // -------------------------------------------------------------
 static uint32_t bmx280_CompensateHumidity(BMxX80_TypeDef* dev) {
-  int32_t adcHumidity = ((int32_t)dev->RawBufPtr[6] << 8) | dev->RawBufPtr[7];
-  BMx280_calib_t* calib = (BMx280_calib_t*)dev->CalibPtr;
+  int32_t adcHumidity = ((int32_t)dev->rawBuffer[6] << 8) | dev->rawBuffer[7];
+  BMx280_Calibration_TypeDef* calib = (BMx280_Calibration_TypeDef*)dev->calibration;
   int32_t humidity = tFine - 76800;
   humidity = (((((adcHumidity << 14) - ((int32_t)calib->dig_h4 << 20)
       - (calib->dig_h5 * humidity)) + 16384) >> 15)

--- a/Periph/Src/bmx680.c
+++ b/Periph/Src/bmx680.c
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : bmx680.c
   * @brief          : Bosch BME680 sensor implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -21,57 +27,57 @@ static uint32_t bmx680_CompensateHumidity(BMxX80_TypeDef*);
 
 // -------------------------------------------------------------
 ErrorStatus BMx680_Init(BMxX80_TypeDef* dev) {
-  if ((dev == NULL) || (dev->I2Cx == NULL) || (dev->RawBufPtr == NULL)
-      || (dev->CalibPtr == NULL) || (dev->Lock != DISABLE)) {
+  if ((dev == NULL) || (dev->i2c == NULL) || (dev->rawBuffer == NULL)
+      || (dev->calibration == NULL) || (dev->lock != DISABLE)) {
     return (ERROR);
   }
-  dev->Lock = ENABLE;
+  dev->lock = ENABLE;
   ErrorStatus status = ERROR;
 
   if (bmx680_Receive(dev, BMX680_DEV_ID, 1U) != SUCCESS) goto done;
-  dev->DevID = dev->RawBufPtr[0];
-  if (dev->DevID != BME680_ID) goto done;
+  dev->deviceId = dev->rawBuffer[0];
+  if (dev->deviceId != BME680_ID) goto done;
   if (bmx680_Receive(dev, BMXX80_UNIQUE_ID_REG, 4U) != SUCCESS) goto done;
-  dev->UniqueID = (
-      ((((uint32_t)dev->RawBufPtr[3]
-        + ((uint32_t)dev->RawBufPtr[2] << 8)) & 0x7FFFU) << 16)
-    | ((uint32_t)dev->RawBufPtr[1] << 8)
-    | (uint32_t)dev->RawBufPtr[0]
+  dev->uniqueId = (
+      ((((uint32_t)dev->rawBuffer[3]
+        + ((uint32_t)dev->rawBuffer[2] << 8)) & 0x7FFFU) << 16)
+    | ((uint32_t)dev->rawBuffer[1] << 8)
+    | (uint32_t)dev->rawBuffer[0]
   );
 
-  BMx680_calib_t* calib = (BMx680_calib_t*)dev->CalibPtr;
+  BMx680_Calibration_TypeDef* calib = (BMx680_Calibration_TypeDef*)dev->calibration;
   if (bmx680_Receive(dev, BMX680_CALIB1, 24U) != SUCCESS) goto done;
-  calib->par_t2 = (int16_t)((dev->RawBufPtr[1] << 8) | dev->RawBufPtr[0]);
-  calib->par_t3 = (int8_t)dev->RawBufPtr[2];
-  calib->par_p1 = (uint16_t)((dev->RawBufPtr[5] << 8) | dev->RawBufPtr[4]);
-  calib->par_p2 = (int16_t)((dev->RawBufPtr[7] << 8) | dev->RawBufPtr[6]);
-  calib->par_p3 = (int8_t)dev->RawBufPtr[8];
-  calib->par_p4 = (int16_t)((dev->RawBufPtr[11] << 8) | dev->RawBufPtr[10]);
-  calib->par_p5 = (int16_t)((dev->RawBufPtr[13] << 8) | dev->RawBufPtr[12]);
-  calib->par_p6 = (int8_t)dev->RawBufPtr[15];
-  calib->par_p7 = (int8_t)dev->RawBufPtr[14];
-  calib->par_p8 = (int16_t)((dev->RawBufPtr[19] << 8) | dev->RawBufPtr[18]);
-  calib->par_p9 = (int16_t)((dev->RawBufPtr[21] << 8) | dev->RawBufPtr[20]);
-  calib->par_p10 = dev->RawBufPtr[22];
+  calib->par_t2 = (int16_t)((dev->rawBuffer[1] << 8) | dev->rawBuffer[0]);
+  calib->par_t3 = (int8_t)dev->rawBuffer[2];
+  calib->par_p1 = (uint16_t)((dev->rawBuffer[5] << 8) | dev->rawBuffer[4]);
+  calib->par_p2 = (int16_t)((dev->rawBuffer[7] << 8) | dev->rawBuffer[6]);
+  calib->par_p3 = (int8_t)dev->rawBuffer[8];
+  calib->par_p4 = (int16_t)((dev->rawBuffer[11] << 8) | dev->rawBuffer[10]);
+  calib->par_p5 = (int16_t)((dev->rawBuffer[13] << 8) | dev->rawBuffer[12]);
+  calib->par_p6 = (int8_t)dev->rawBuffer[15];
+  calib->par_p7 = (int8_t)dev->rawBuffer[14];
+  calib->par_p8 = (int16_t)((dev->rawBuffer[19] << 8) | dev->rawBuffer[18]);
+  calib->par_p9 = (int16_t)((dev->rawBuffer[21] << 8) | dev->rawBuffer[20]);
+  calib->par_p10 = dev->rawBuffer[22];
   if (calib->par_p1 == 0U) goto done;
 
   if (bmx680_Receive(dev, BMX680_CALIB2, 16U) != SUCCESS) goto done;
-  calib->par_h1 = (uint16_t)((dev->RawBufPtr[2] << 4) | (dev->RawBufPtr[1] & 0x0FU));
-  calib->par_h2 = (uint16_t)((dev->RawBufPtr[0] << 4) | (dev->RawBufPtr[1] >> 4));
-  calib->par_h3 = (int8_t)dev->RawBufPtr[3];
-  calib->par_h4 = (int8_t)dev->RawBufPtr[4];
-  calib->par_h5 = (int8_t)dev->RawBufPtr[5];
-  calib->par_h6 = dev->RawBufPtr[6];
-  calib->par_h7 = (int8_t)dev->RawBufPtr[7];
-  calib->par_t1 = (uint16_t)((dev->RawBufPtr[9] << 8) | dev->RawBufPtr[8]);
-  calib->par_g1 = (int8_t)dev->RawBufPtr[12];
-  calib->par_g2 = (int16_t)((dev->RawBufPtr[11] << 8) | dev->RawBufPtr[10]);
-  calib->par_g3 = (int8_t)dev->RawBufPtr[13];
+  calib->par_h1 = (uint16_t)((dev->rawBuffer[2] << 4) | (dev->rawBuffer[1] & 0x0FU));
+  calib->par_h2 = (uint16_t)((dev->rawBuffer[0] << 4) | (dev->rawBuffer[1] >> 4));
+  calib->par_h3 = (int8_t)dev->rawBuffer[3];
+  calib->par_h4 = (int8_t)dev->rawBuffer[4];
+  calib->par_h5 = (int8_t)dev->rawBuffer[5];
+  calib->par_h6 = dev->rawBuffer[6];
+  calib->par_h7 = (int8_t)dev->rawBuffer[7];
+  calib->par_t1 = (uint16_t)((dev->rawBuffer[9] << 8) | dev->rawBuffer[8]);
+  calib->par_g1 = (int8_t)dev->rawBuffer[12];
+  calib->par_g2 = (int16_t)((dev->rawBuffer[11] << 8) | dev->rawBuffer[10]);
+  calib->par_g3 = (int8_t)dev->rawBuffer[13];
 
   status = SUCCESS;
 
 done:
-  dev->Lock = DISABLE;
+  dev->lock = DISABLE;
   return (status);
 }
 
@@ -79,9 +85,9 @@ done:
 
 
 // -------------------------------------------------------------
-ErrorStatus BMx680_Measurement(BMxX80_TypeDef* dev) {
-  if ((dev == NULL) || (dev->Lock != DISABLE)) return (ERROR);
-  dev->Lock = ENABLE;
+ErrorStatus BMx680_Measure(BMxX80_TypeDef* dev) {
+  if ((dev == NULL) || (dev->lock != DISABLE)) return (ERROR);
+  dev->lock = ENABLE;
   ErrorStatus status = ERROR;
 
   if (bmx680_Send(dev, BMX680_CTRL_HUM, BMX680_HUMIDITY_OVS_4) != SUCCESS) {
@@ -95,33 +101,33 @@ ErrorStatus BMx680_Measurement(BMxX80_TypeDef* dev) {
 
   uint16_t timeout = 250U;
   do {
-    _delay_ms(1U);
+    Delay_Milliseconds(1U);
     if (bmx680_Receive(dev, BMX680_STATUS, 1U) != SUCCESS) goto done;
-    if ((dev->RawBufPtr[0] & BMX680_MEASURING) == 0U) break;
+    if ((dev->rawBuffer[0] & BMX680_MEASURING) == 0U) break;
   } while (--timeout != 0U);
   if (timeout == 0U) goto done;
 
   if (bmx680_Receive(dev, BMX680_DATA, 8U) != SUCCESS) goto done;
   uint32_t rawPressure = (
-      ((uint32_t)dev->RawBufPtr[0] << 12)
-    | ((uint32_t)dev->RawBufPtr[1] << 4)
-    | ((uint32_t)dev->RawBufPtr[2] >> 4)
+      ((uint32_t)dev->rawBuffer[0] << 12)
+    | ((uint32_t)dev->rawBuffer[1] << 4)
+    | ((uint32_t)dev->rawBuffer[2] >> 4)
   );
   uint32_t rawTemperature = (
-      ((uint32_t)dev->RawBufPtr[3] << 12)
-    | ((uint32_t)dev->RawBufPtr[4] << 4)
-    | ((uint32_t)dev->RawBufPtr[5] >> 4)
+      ((uint32_t)dev->rawBuffer[3] << 12)
+    | ((uint32_t)dev->rawBuffer[4] << 4)
+    | ((uint32_t)dev->rawBuffer[5] >> 4)
   );
   if ((rawPressure == 0x80000U) || (rawTemperature == 0x80000U)) goto done;
 
   bmx680_CompensateTemperature(dev);
-  dev->Results.pressure = bmx680_CompensatePressure(dev);
-  dev->Results.humidity = bmx680_CompensateHumidity(dev);
+  dev->results.pressure = bmx680_CompensatePressure(dev);
+  dev->results.humidity = bmx680_CompensateHumidity(dev);
 
   status = SUCCESS;
 
 done:
-  dev->Lock = DISABLE;
+  dev->lock = DISABLE;
   return (status);
 }
 
@@ -131,7 +137,7 @@ done:
 // -------------------------------------------------------------
 static ErrorStatus bmx680_Send(BMxX80_TypeDef* dev, uint8_t reg, uint8_t value) {
   uint8_t buffer[2] = {reg, value};
-  return I2C_Master_Send(dev->I2Cx, dev->I2C_Address, buffer, sizeof(buffer));
+  return I2C_Master_Send(dev->i2c, dev->i2cAddress, buffer, sizeof(buffer));
 }
 
 
@@ -140,10 +146,10 @@ static ErrorStatus bmx680_Send(BMxX80_TypeDef* dev, uint8_t reg, uint8_t value) 
 // -------------------------------------------------------------
 static ErrorStatus bmx680_Receive(BMxX80_TypeDef* dev, uint8_t reg, uint8_t length) {
   return I2C_Master_ReadRegister(
-    dev->I2Cx,
-    dev->I2C_Address,
+    dev->i2c,
+    dev->i2cAddress,
     reg,
-    dev->RawBufPtr,
+    dev->rawBuffer,
     length
   );
 }
@@ -154,17 +160,17 @@ static ErrorStatus bmx680_Receive(BMxX80_TypeDef* dev, uint8_t reg, uint8_t leng
 // -------------------------------------------------------------
 static void bmx680_CompensateTemperature(BMxX80_TypeDef* dev) {
   uint32_t adcTemperature = (
-      ((uint32_t)dev->RawBufPtr[3] << 12)
-    | ((uint32_t)dev->RawBufPtr[4] << 4)
-    | ((uint32_t)dev->RawBufPtr[5] >> 4)
+      ((uint32_t)dev->rawBuffer[3] << 12)
+    | ((uint32_t)dev->rawBuffer[4] << 4)
+    | ((uint32_t)dev->rawBuffer[5] >> 4)
   );
-  BMx680_calib_t* calib = (BMx680_calib_t*)dev->CalibPtr;
+  BMx680_Calibration_TypeDef* calib = (BMx680_Calibration_TypeDef*)dev->calibration;
   int32_t var1 = ((int32_t)(adcTemperature >> 3) - ((int32_t)calib->par_t1 << 1));
   int32_t var2 = (var1 * calib->par_t2) >> 11;
   int32_t var3 = ((((var1 >> 1) * (var1 >> 1)) >> 12)
                   * ((int32_t)calib->par_t3 << 4)) >> 14;
   tFine = var2 + var3;
-  dev->Results.temperature = (tFine * 5 + 128) >> 8;
+  dev->results.temperature = (tFine * 5 + 128) >> 8;
 }
 
 
@@ -173,11 +179,11 @@ static void bmx680_CompensateTemperature(BMxX80_TypeDef* dev) {
 // -------------------------------------------------------------
 static uint32_t bmx680_CompensatePressure(BMxX80_TypeDef* dev) {
   uint32_t adcPressure = (
-      ((uint32_t)dev->RawBufPtr[0] << 12)
-    | ((uint32_t)dev->RawBufPtr[1] << 4)
-    | ((uint32_t)dev->RawBufPtr[2] >> 4)
+      ((uint32_t)dev->rawBuffer[0] << 12)
+    | ((uint32_t)dev->rawBuffer[1] << 4)
+    | ((uint32_t)dev->rawBuffer[2] >> 4)
   );
-  BMx680_calib_t* calib = (BMx680_calib_t*)dev->CalibPtr;
+  BMx680_Calibration_TypeDef* calib = (BMx680_Calibration_TypeDef*)dev->calibration;
   int32_t var1 = (tFine >> 1) - 64000;
   int32_t var2 = (((((var1 >> 2) * (var1 >> 2)) >> 11) * calib->par_p6) >> 2);
   var2 += (var1 * calib->par_p5) << 1;
@@ -213,9 +219,9 @@ static uint32_t bmx680_CompensatePressure(BMxX80_TypeDef* dev) {
 // -------------------------------------------------------------
 static uint32_t bmx680_CompensateHumidity(BMxX80_TypeDef* dev) {
   uint16_t adcHumidity = (uint16_t)(
-    ((uint16_t)dev->RawBufPtr[6] << 8) | dev->RawBufPtr[7]
+    ((uint16_t)dev->rawBuffer[6] << 8) | dev->rawBuffer[7]
   );
-  BMx680_calib_t* calib = (BMx680_calib_t*)dev->CalibPtr;
+  BMx680_Calibration_TypeDef* calib = (BMx680_Calibration_TypeDef*)dev->calibration;
   int32_t temperature = ((tFine * 5) + 128) >> 8;
   int32_t var1 = (int32_t)adcHumidity - ((int32_t)calib->par_h1 * 16)
     - (((temperature * calib->par_h3) / 100) >> 1);

--- a/Periph/Src/bmxx80.c
+++ b/Periph/Src/bmxx80.c
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : bmxx80.c
   * @brief          : Bosch BMx sensor device instances.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -11,34 +17,34 @@
 #include <stddef.h>
 
 static uint8_t bmx280RawData[32];
-static BMx280_calib_t bmx280Calibration;
+static BMx280_Calibration_TypeDef bmx280Calibration;
 static BMxX80_TypeDef bmx280Device = {
-  .DevID = 0U,
-  .RawBufPtr = bmx280RawData,
-  .Results = {0},
-  .CalibPtr = &bmx280Calibration,
-  .Lock = DISABLE,
-  .I2Cx = I2C1,
-  .I2C_Address = BMX280_I2C_ADDR,
+  .deviceId = 0U,
+  .rawBuffer = bmx280RawData,
+  .results = {0},
+  .calibration = &bmx280Calibration,
+  .lock = DISABLE,
+  .i2c = I2C1,
+  .i2cAddress = BMX280_I2C_ADDR,
 };
 
 static uint8_t bmx680RawData[24];
-static BMx680_calib_t bmx680Calibration;
+static BMx680_Calibration_TypeDef bmx680Calibration;
 static BMxX80_TypeDef bmx680Device = {
-  .DevID = 0U,
-  .RawBufPtr = bmx680RawData,
-  .Results = {0},
-  .CalibPtr = &bmx680Calibration,
-  .Lock = DISABLE,
-  .I2Cx = I2C1,
-  .I2C_Address = BMX680_I2C_ADDR,
+  .deviceId = 0U,
+  .rawBuffer = bmx680RawData,
+  .results = {0},
+  .calibration = &bmx680Calibration,
+  .lock = DISABLE,
+  .i2c = I2C1,
+  .i2cAddress = BMX680_I2C_ADDR,
 };
 
 
 
 
 // -------------------------------------------------------------
-BMxX80_TypeDef* Get_BoschDevice(uint16_t model) {
+BMxX80_TypeDef* BMxX80_GetDevice(uint16_t model) {
   if (model == BMX280_MODEL) return (&bmx280Device);
   if (model == BMX680_MODEL) return (&bmx680Device);
   return (NULL);

--- a/Periph/Src/dot_10x14.c
+++ b/Periph/Src/dot_10x14.c
@@ -1,12 +1,15 @@
-/*
- * Filename: dot_10x14.c
- * Description: The file contains simple 10x14 dot font code.
- *
- * Project: Simple Multitasking Logic
- * Platform: MicroChip ATTiny85
- * Created: 10.08.2025 07:35:51 PM
- * Author: Dmitry Slobodchikov
- */
+/**
+  ******************************************************************************
+  * @file           : dot_10x14.c
+  * @brief          : Bitmap data for the 10x14 display font.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 03:58:46 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
 
 #include "fonts.h"
 

--- a/Periph/Src/dot_5x7.c
+++ b/Periph/Src/dot_5x7.c
@@ -1,12 +1,15 @@
-/*
- * Filename: dot_5x7.c
- * Description: The file contains simple 5x7 dot font code.
- *
- * Project: Simple Multitasking Logic
- * Platform: MicroChip ATTiny85
- * Created: 10.08.2025 07:35:51 PM
- * Author: Dmitry Slobodchikov
- */
+/**
+  ******************************************************************************
+  * @file           : dot_5x7.c
+  * @brief          : Bitmap data for the 5x7 display font.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 03:58:46 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
 
 #include "fonts.h"
 

--- a/Periph/Src/ds18b20.c
+++ b/Periph/Src/ds18b20.c
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : ds18b20.c
-  *                   This file contains OneWire DS18B20 temperature sensor
-  *                   code. 
+  * @brief          : DS18B20 temperature sensor implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 04:30:00 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -30,7 +32,7 @@ static DS18B20_Status_TypeDef dS18B20_ConvertTemperature(uint8_t*);
 static ErrorStatus dS18B20_WaitStatus(uint16_t);
 
 static DS18B20_Status_TypeDef DS18B20_GetTemperatureMeasurement(
-  OneWireDevice_t*
+  OneWireDevice_TypeDef*
 );
 
 static int16_t dS18B20_DecodeTemperature(const uint8_t*);
@@ -54,12 +56,12 @@ ErrorStatus DS18B20_Measure(
     return (ERROR);
   }
 
-  OneWireDevice_t* devices = Get_OwDevices();
+  OneWireDevice_TypeDef* devices = OneWire_GetDevices();
   for (uint8_t i = 0; i < readCount; i++) {
-    memcpy(measurements[i].rom, devices[i].addr, sizeof(measurements[i].rom));
+    memcpy(measurements[i].rom, devices[i].rom, sizeof(measurements[i].rom));
     measurements[i].status = DS18B20_GetTemperatureMeasurement(&devices[i]);
     if (measurements[i].status == DS18B20_STATUS_OK) {
-      measurements[i].temperature = dS18B20_DecodeTemperature(devices[i].spad);
+      measurements[i].temperature = dS18B20_DecodeTemperature(devices[i].scratchpad);
     } else {
       measurements[i].temperature = 0;
     }
@@ -96,7 +98,7 @@ static DS18B20_Status_TypeDef dS18B20_ReadScratchpad(
 ) {
 
   if (OneWire_MatchROM(addr)) return (DS18B20_STATUS_BUS);
-  dS18B20_Command(ReadScratchpad);
+  dS18B20_Command(DS18B20_COMMAND_READ_SCRATCHPAD);
 
   uint8_t crc = 0;
   for (int8_t i = 0; i < 9; i++) {
@@ -120,7 +122,7 @@ static DS18B20_Status_TypeDef dS18B20_ConvertTemperature(uint8_t* addr) {
     uint8_t pps = OneWire_ReadPowerSupply(addr);
     
     if (OneWire_MatchROM(addr)) return (DS18B20_STATUS_BUS);
-    dS18B20_Command(ConvertT);
+    dS18B20_Command(DS18B20_COMMAND_CONVERT_T);
     
     if (pps) {
       OneWire_StrongPullupEnable();
@@ -134,8 +136,8 @@ static DS18B20_Status_TypeDef dS18B20_ConvertTemperature(uint8_t* addr) {
   } else {
     if (OneWire_Reset()) return (DS18B20_STATUS_BUS);
     
-    dS18B20_Command(SkipROM);
-    dS18B20_Command(ConvertT);
+    dS18B20_Command(ONEWIRE_COMMAND_SKIP_ROM);
+    dS18B20_Command(DS18B20_COMMAND_CONVERT_T);
     if (dS18B20_WaitStatus(DS18B20_CONVERSION_TIMEOUT_MS) != SUCCESS) {
       return (DS18B20_STATUS_TIMEOUT);
     }
@@ -163,10 +165,10 @@ static ErrorStatus dS18B20_WaitStatus(uint16_t timeoutMs) {
 // -------------------------------------------------------------  
 // -------------------------------------------------------------  
 static DS18B20_Status_TypeDef DS18B20_GetTemperatureMeasurement(
-  OneWireDevice_t* dev
+  OneWireDevice_TypeDef* dev
 ) {
-  DS18B20_Status_TypeDef status = dS18B20_ConvertTemperature(dev->addr);
+  DS18B20_Status_TypeDef status = dS18B20_ConvertTemperature(dev->rom);
   if (status != DS18B20_STATUS_OK) return (status);
 
-  return dS18B20_ReadScratchpad(dev->spad, dev->addr);
+  return dS18B20_ReadScratchpad(dev->scratchpad, dev->rom);
 }

--- a/Periph/Src/gpio.c
+++ b/Periph/Src/gpio.c
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
-  * @file           : led.c
-  * @brief          : This file contains the common defines for the GPIO
-  *                   initialization functions. 
+  * @file           : gpio.c
+  * @brief          : GPIO initialization implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 02:40:44 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -55,7 +57,7 @@ ErrorStatus OneWire_Init(GPIO_TypeDef *port, uint16_t pin) {
 
 
 
-ErrorStatus EthSPI_Init(GPIO_TypeDef *port, uint16_t pin) {
+ErrorStatus EthernetSPI_Init(GPIO_TypeDef *port, uint16_t pin) {
     uint32_t shift;
     #define SPI_ETH_PP_50MHZ (GPIO_IOS_50 | GPIO_GPO_PP)
 

--- a/Periph/Src/i2c.c
+++ b/Periph/Src/i2c.c
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : i2c.c
-  * @brief          : Polling I2C master-mode peripheral interface.
+  * @brief          : Polling I2C master-mode peripheral implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 04:51:32 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -35,10 +41,10 @@ ErrorStatus I2C_Init(I2C_TypeDef* i2c) {
   MODIFY_REG(
     GPIOB->CRL,
     GPIO_PIN_6_Mask | GPIO_PIN_7_Mask,
-    (pinMode << (I2C1_SCL_Pin * 4U)) | (pinMode << (I2C1_SDA_Pin * 4U))
+    (pinMode << (I2C1_SCL_PIN * 4U)) | (pinMode << (I2C1_SDA_PIN * 4U))
   );
-  PIN_H(I2C1_SCL_Port, I2C1_SCL_Pin);
-  PIN_H(I2C1_SDA_Port, I2C1_SDA_Pin);
+  PIN_H(I2C1_SCL_PORT, I2C1_SCL_PIN);
+  PIN_H(I2C1_SDA_PORT, I2C1_SDA_PIN);
 
   CLEAR_BIT(i2c->CR1, I2C_CR1_PE);
   SET_BIT(RCC->APB1RSTR, RCC_APB1RSTR_I2C1RST);

--- a/Periph/Src/onewire.c
+++ b/Periph/Src/onewire.c
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : onewire.c
-  *                   This file contains OneWire bus and dedicated GPIO 
-  *                   initialization.
+  * @brief          : One-wire bus and device implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 23.09.2025 04:55:12 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -25,14 +27,14 @@ static void oneWireBusConfigurationTask(void* parameters);
 
 
 /* Private defines -----------------------------------------------------------*/
-#define _delay_ms vTaskDelay
+#define Delay_Milliseconds vTaskDelay
 
 /* Global variables ----------------------------------------------------------*/
 
 /* Private variables ---------------------------------------------------------*/
 #define NUM_DEVICES_ON_BUS 16
 static uint8_t lastfork;
-static OneWireDevice_t oneWireDevices[NUM_DEVICES_ON_BUS];
+static OneWireDevice_TypeDef oneWireDevices[NUM_DEVICES_ON_BUS];
 static uint8_t oneWireDeviceCount;
 static StaticSemaphore_t oneWireMutexBuffer;
 static SemaphoreHandle_t oneWireMutex;
@@ -44,7 +46,7 @@ static SemaphoreHandle_t oneWireMutex;
 /*******************************************************************************/
 
 // -------------------------------------------------------------
-void OneWireBusConfigurationInit(void) {
+void OneWireBusConfiguration_Init(void) {
   oneWireMutex = xSemaphoreCreateMutexStatic(&oneWireMutexBuffer);
 
   static StaticTask_t oneWireBusConfigurationTaskTCB;
@@ -102,11 +104,11 @@ void OneWire_Unlock(void) {
 
 // -------------------------------------------------------------
 void OneWire_StrongPullupEnable(void) {
-  uint32_t shift = (OneWire_PIN - 8U) * 4U;
+  uint32_t shift = (ONEWIRE_PIN - 8U) * 4U;
 
-  PIN_H(OneWire_PORT, OneWire_PIN);
+  PIN_H(ONEWIRE_PORT, ONEWIRE_PIN);
   MODIFY_REG(
-    OneWire_PORT->CRH,
+    ONEWIRE_PORT->CRH,
     (0xfU << shift),
     ((GPIO_IOS_10 | GPIO_GPO_PP) << shift)
   );
@@ -117,11 +119,11 @@ void OneWire_StrongPullupEnable(void) {
 
 // -------------------------------------------------------------
 void OneWire_StrongPullupDisable(void) {
-  uint32_t shift = (OneWire_PIN - 8U) * 4U;
+  uint32_t shift = (ONEWIRE_PIN - 8U) * 4U;
 
-  PIN_H(OneWire_PORT, OneWire_PIN);
+  PIN_H(ONEWIRE_PORT, ONEWIRE_PIN);
   MODIFY_REG(
-    OneWire_PORT->CRH,
+    ONEWIRE_PORT->CRH,
     (0xfU << shift),
     ((GPIO_IOS_10 | GPIO_GPO_OD) << shift)
   );
@@ -154,26 +156,26 @@ ErrorStatus OneWire_Reset(void) {
 
   uint32_t p = irq_lock();
 
-  OneWire_High;
-  _delay_us(580);
-  OneWire_Low;
-  _delay_us(15);
+  ONEWIRE_RELEASE;
+  Delay_Microseconds(580);
+  ONEWIRE_DRIVE_LOW;
+  Delay_Microseconds(15);
   
   int i = 0;
   ErrorStatus status = ERROR;
   while (i++ < 240) {
-    if (!OneWire_Level) {
+    if (!ONEWIRE_LEVEL) {
       status = SUCCESS;
       break;
     }
-    _delay_us(1);
+    Delay_Microseconds(1);
   }
 
   /* to prevent non pulled-up pin to response */
   if (i == 1) {
     status = SUCCESS;
   } else {
-    _delay_us(580 - i);
+    Delay_Microseconds(580 - i);
   }
 
   irq_unlock(p);
@@ -186,15 +188,15 @@ __STATIC_INLINE void OneWire_WriteBit(uint8_t bit) {
 
   uint32_t p = irq_lock();
 
-  OneWire_High;
+  ONEWIRE_RELEASE;
   if (bit) {
-    _delay_us(6);
-    OneWire_Low;
-    _delay_us(64);
+    Delay_Microseconds(6);
+    ONEWIRE_DRIVE_LOW;
+    Delay_Microseconds(64);
   } else {
-    _delay_us(60);
-    OneWire_Low;
-    _delay_us(10);
+    Delay_Microseconds(60);
+    ONEWIRE_DRIVE_LOW;
+    Delay_Microseconds(10);
   }
 
   irq_unlock(p);
@@ -216,12 +218,12 @@ uint8_t OneWire_ReadBit(void) {
 
   uint32_t p = irq_lock();
 
-  OneWire_High;
-  _delay_us(6);
-  OneWire_Low;
-  _delay_us(9);
-  uint8_t level = OneWire_Level;
-  _delay_us(55);
+  ONEWIRE_RELEASE;
+  Delay_Microseconds(6);
+  ONEWIRE_DRIVE_LOW;
+  Delay_Microseconds(9);
+  uint8_t level = ONEWIRE_LEVEL;
+  Delay_Microseconds(55);
 
   irq_unlock(p);
   
@@ -283,7 +285,7 @@ __STATIC_INLINE ErrorStatus OneWire_Enumerate(uint8_t* addr) {
 	uint8_t bit0 = 0;
 	uint8_t bit1 = 0;
   
-	OneWire_WriteByte(SearchROM);
+	OneWire_WriteByte(ONEWIRE_COMMAND_SEARCH_ROM);
   
 	for(uint8_t i = 1; i < 65; i++) {
     bit0 = OneWire_ReadBit();
@@ -337,7 +339,7 @@ ErrorStatus OneWire_Search(void) {
   if (OneWire_Reset()) return (ERROR);
   lastfork = 65;
   for (uint8_t i = 0; i < NUM_DEVICES_ON_BUS; i++) {
-    if (OneWire_Enumerate(oneWireDevices[i].addr)) break;
+    if (OneWire_Enumerate(oneWireDevices[i].rom)) break;
     oneWireDeviceCount++;
   }
   return (oneWireDeviceCount > 0U) ? SUCCESS : ERROR;
@@ -347,7 +349,7 @@ ErrorStatus OneWire_Search(void) {
 // -------------------------------------------------------------
 uint8_t OneWire_ReadPowerSupply(uint8_t* addr) {
   OneWire_MatchROM(addr);
-  OneWire_WriteByte(ReadPowerSupply);
+  OneWire_WriteByte(ONEWIRE_COMMAND_READ_POWER_SUPPLY);
   
   return !OneWire_ReadBit();
 }
@@ -361,7 +363,7 @@ uint8_t OneWire_ReadPowerSupply(uint8_t* addr) {
 ErrorStatus OneWire_MatchROM(uint8_t* addr) {
   if (OneWire_Reset()) return (ERROR);
   
-  OneWire_WriteByte(MatchROM);
+  OneWire_WriteByte(ONEWIRE_COMMAND_MATCH_ROM);
   for (uint8_t i = 0; i < 8; i++) {
     OneWire_WriteByte(addr[i]);
   }
@@ -371,7 +373,7 @@ ErrorStatus OneWire_MatchROM(uint8_t* addr) {
 
 
 // -------------------------------------------------------------
-OneWireDevice_t* Get_OwDevices(void) {
+OneWireDevice_TypeDef* OneWire_GetDevices(void) {
   return oneWireDevices;
 }
 

--- a/Periph/Src/spi.c
+++ b/Periph/Src/spi.c
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : spi.c
-  * @brief          : This file contains the common defines for the SPI 
-  *                   initialization functions.
+  * @brief          : SPI peripheral implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 12:54:49 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -20,34 +22,34 @@
 /* Private function prototypes -----------------------------------------------*/
 
 
-ErrorStatus SPI_Init(SPI_TypeDef* SPIx) {
+ErrorStatus SPI_Init(SPI_TypeDef* spi) {
 
   /* Enable GPIO SCK, MISO, MOSI alternative on high speed */
 
-  if (SPIx == SPI1) {
+  if (spi == SPI1) {
 
-    MODIFY_REG(SPI1_Port->CRL,
-      ((0xf << (SPI1_SCK_Pin * 4U)) | (0xf << (SPI1_MISO_Pin * 4U)) | (0xf << (SPI1_MOSI_Pin * 4U))), (
-        ((GPIO_AF_PP | GPIO_IOS_50) << (SPI1_SCK_Pin * 4U))
-      | (GPIO_IN_FL << (SPI1_MISO_Pin * 4U))
-      | ((GPIO_AF_PP | GPIO_IOS_50) << (SPI1_MOSI_Pin * 4U))
+    MODIFY_REG(SPI1_PORT->CRL,
+      ((0xf << (SPI1_SCK_PIN * 4U)) | (0xf << (SPI1_MISO_PIN * 4U)) | (0xf << (SPI1_MOSI_PIN * 4U))), (
+        ((GPIO_AF_PP | GPIO_IOS_50) << (SPI1_SCK_PIN * 4U))
+      | (GPIO_IN_FL << (SPI1_MISO_PIN * 4U))
+      | ((GPIO_AF_PP | GPIO_IOS_50) << (SPI1_MOSI_PIN * 4U))
     ));
     /* Enbale SPI master mode */
-    SET_BIT(SPIx->CR1, SPI_CR1_MSTR);
+    SET_BIT(spi->CR1, SPI_CR1_MSTR);
   }
 
-  if (SPIx == SPI2) {
-    MODIFY_REG(SPI2_Port->CRH,
-      ((0xf << ((SPI2_SCK_Pin - 8) * 4U)) | (0xf << ((SPI2_MISO_Pin - 8) * 4U)) | (0xf << ((SPI2_MOSI_Pin - 8) * 4U))), (
-        ((GPIO_AF_PP | GPIO_IOS_50) << ((SPI2_SCK_Pin - 8) * 4U))
-      | (GPIO_IN_FL << ((SPI2_MISO_Pin - 8) * 4U))
-      | ((GPIO_AF_PP | GPIO_IOS_50) << ((SPI2_MOSI_Pin - 8) * 4U))
+  if (spi == SPI2) {
+    MODIFY_REG(SPI2_PORT->CRH,
+      ((0xf << ((SPI2_SCK_PIN - 8) * 4U)) | (0xf << ((SPI2_MISO_PIN - 8) * 4U)) | (0xf << ((SPI2_MOSI_PIN - 8) * 4U))), (
+        ((GPIO_AF_PP | GPIO_IOS_50) << ((SPI2_SCK_PIN - 8) * 4U))
+      | (GPIO_IN_FL << ((SPI2_MISO_PIN - 8) * 4U))
+      | ((GPIO_AF_PP | GPIO_IOS_50) << ((SPI2_MOSI_PIN - 8) * 4U))
     ));
     /* Enbale SPI master mode */
-    SET_BIT(SPIx->CR1, SPI_CR1_MSTR);
+    SET_BIT(spi->CR1, SPI_CR1_MSTR);
   }
 
-  switch ((uint32_t)SPIx) {
+  switch ((uint32_t)spi) {
   case (uint32_t)SPI1:
     // NVIC_SetPriority(SPI1_IRQn, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 15, 0));
     // NVIC_EnableIRQ(SPI1_IRQn);
@@ -70,10 +72,10 @@ ErrorStatus SPI_Init(SPI_TypeDef* SPIx) {
 
 // ----------------------------------------------------------------------------
 
-ErrorStatus SPI_AdjustInit(SPI_TypeDef* SPIx) {
+ErrorStatus SPI_AdjustConfiguration(SPI_TypeDef* spi) {
 
-  MODIFY_REG(SPIx->CR1, (SPI_CR1_BR_Msk | SPI_CR1_DFF_Msk), 0);
-  PREG_SET(SPIx->CR2, SPI_CR2_SSOE_Pos);
+  MODIFY_REG(spi->CR1, (SPI_CR1_BR_Msk | SPI_CR1_DFF_Msk), 0);
+  PREG_SET(spi->CR2, SPI_CR2_SSOE_Pos);
 
   return (SUCCESS);
 }
@@ -82,18 +84,18 @@ ErrorStatus SPI_AdjustInit(SPI_TypeDef* SPIx) {
 
 // ----------------------------------------------------------------------------
 
-ErrorStatus SPI_Enable(SPI_TypeDef* SPIx) {
+ErrorStatus SPI_Enable(SPI_TypeDef* spi) {
 
-  uint32_t tmout = SPI_BUS_TMOUT;
+  uint32_t tmout = SPI_BUS_TIMEOUT;
 
-  while(PREG_CHECK(SPIx->SR, SPI_SR_BSY_Pos)) {
+  while(PREG_CHECK(spi->SR, SPI_SR_BSY_Pos)) {
     if (!(--tmout)) {
-      SPI_Disable(SPIx);
+      SPI_Disable(spi);
       return (ERROR);
     }
   }
 
-  PREG_SET(SPIx->CR1, SPI_CR1_SPE_Pos);
+  PREG_SET(spi->CR1, SPI_CR1_SPE_Pos);
   return (SUCCESS);
 }
 
@@ -102,16 +104,16 @@ ErrorStatus SPI_Enable(SPI_TypeDef* SPIx) {
 
 // ----------------------------------------------------------------------------
 
-ErrorStatus SPI_Disable(SPI_TypeDef* SPIx) {
-  uint32_t tmout = SPI_BUS_TMOUT;
+ErrorStatus SPI_Disable(SPI_TypeDef* spi) {
+  uint32_t tmout = SPI_BUS_TIMEOUT;
   
-  while(PREG_CHECK(SPIx->SR, SPI_SR_BSY_Pos)) {
+  while(PREG_CHECK(spi->SR, SPI_SR_BSY_Pos)) {
     if (!(--tmout)) {
       return (ERROR);
     }
   }
   
-  PREG_CLR(SPIx->CR1, SPI_CR1_SPE_Pos);
+  PREG_CLR(spi->CR1, SPI_CR1_SPE_Pos);
   return (SUCCESS);
 }
 
@@ -120,22 +122,22 @@ ErrorStatus SPI_Disable(SPI_TypeDef* SPIx) {
 
 // ----------------------------------------------------------------------------
 
-ErrorStatus SPI_Read_8b(SPI_TypeDef* SPIx, uint8_t *buf, uint16_t cnt) {
+ErrorStatus SPI_Read8(SPI_TypeDef* spi, uint8_t *buffer, uint16_t length) {
   uint32_t tmout = 0;
   
-  while (cnt--) {
-    *(__IO uint8_t*)&SPIx->DR = 0;
+  while (length--) {
+    *(__IO uint8_t*)&spi->DR = 0;
     
-    tmout = SPI_BUS_TMOUT;
-    while(!(PREG_CHECK(SPIx->SR, SPI_SR_TXE_Pos))) {
+    tmout = SPI_BUS_TIMEOUT;
+    while(!(PREG_CHECK(spi->SR, SPI_SR_TXE_Pos))) {
       if (!(--tmout)) return (ERROR);
     }
     
-    tmout = SPI_BUS_TMOUT;
-    while(!(PREG_CHECK(SPIx->SR, SPI_SR_RXNE_Pos))) {
+    tmout = SPI_BUS_TIMEOUT;
+    while(!(PREG_CHECK(spi->SR, SPI_SR_RXNE_Pos))) {
       if (!(--tmout)) return (ERROR);
     }
-    *buf++ = (uint8_t)SPIx->DR;
+    *buffer++ = (uint8_t)spi->DR;
   }
   
   return (SUCCESS);
@@ -145,22 +147,22 @@ ErrorStatus SPI_Read_8b(SPI_TypeDef* SPIx, uint8_t *buf, uint16_t cnt) {
 
 // ----------------------------------------------------------------------------
 
-ErrorStatus SPI_Write_8b(SPI_TypeDef* SPIx, uint8_t *buf, uint16_t cnt) {
+ErrorStatus SPI_Write8(SPI_TypeDef* spi, uint8_t *buffer, uint16_t length) {
   uint32_t tmout = 0;
   
-  while (cnt--) {
-    *(__IO uint8_t*)&SPIx->DR = *buf++;
+  while (length--) {
+    *(__IO uint8_t*)&spi->DR = *buffer++;
     
-    tmout = SPI_BUS_TMOUT;
-    while(!(PREG_CHECK(SPIx->SR, SPI_SR_TXE_Pos))) {
+    tmout = SPI_BUS_TIMEOUT;
+    while(!(PREG_CHECK(spi->SR, SPI_SR_TXE_Pos))) {
       if (!(--tmout)) return (ERROR);
     }
     
-    tmout = SPI_BUS_TMOUT;
-    while(!(PREG_CHECK(SPIx->SR, SPI_SR_RXNE_Pos))) {
+    tmout = SPI_BUS_TIMEOUT;
+    while(!(PREG_CHECK(spi->SR, SPI_SR_RXNE_Pos))) {
       if (!(--tmout)) return (ERROR);
     }
-    (SPIx->DR);
+    (spi->DR);
   }
   
   return (SUCCESS);

--- a/Periph/Src/ssd13xx.c
+++ b/Periph/Src/ssd13xx.c
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : ssd13xx.c
-  * @brief          : SSD1306/SSD1315 display interface over I2C.
+  * @brief          : SSD1306 and SSD1315 display implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 03:58:46 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -60,10 +66,10 @@ ErrorStatus SSD13xx_Init(
   displayMutex = xSemaphoreCreateMutexStatic(&displayMutexBuffer);
   if (displayMutex == NULL) return (ERROR);
 
-  device->I2C = i2c;
-  device->Address = address;
-  device->Model = model;
-  device->Font = font;
+  device->i2c = i2c;
+  device->address = address;
+  device->model = model;
+  device->font = font;
   displayDevice = device;
   displayColumn = 0U;
   displayRow = 0U;
@@ -74,7 +80,7 @@ ErrorStatus SSD13xx_Init(
     0xD9U, 0x88U, 0xDBU, 0x20U, 0xA4U, 0xA6U, 0xAFU
   };
 
-  _delay_ms(15U);
+  Delay_Milliseconds(15U);
   if (ssd13xx_SendCommands(
         device,
         initCommands,
@@ -109,8 +115,8 @@ ErrorStatus SSD13xx_Clear(SSD13xx_TypeDef* device) {
   uint8_t clearBuffer[17] = {SSD13XX_DATA_CONTROL};
   for (uint8_t block = 0U; (block < 64U) && (status == SUCCESS); block++) {
     status = I2C_Master_Send(
-      device->I2C,
-      device->Address,
+      device->i2c,
+      device->address,
       clearBuffer,
       sizeof(clearBuffer)
     );
@@ -125,13 +131,13 @@ ErrorStatus SSD13xx_Clear(SSD13xx_TypeDef* device) {
 
 
 // -------------------------------------------------------------
-int putc_dspl_ssd(char character) {
+int SSD13xx_PutChar(char character) {
   if ((displayDevice == NULL) || (displayMutex == NULL)) return (ERROR);
   if (xSemaphoreTake(displayMutex, portMAX_DELAY) != pdTRUE) return (ERROR);
 
   ErrorStatus status = SUCCESS;
-  uint8_t columns = (displayDevice->Font == SSD13XX_FONT_10X14) ? 10U : 21U;
-  uint8_t rows = (displayDevice->Font == SSD13XX_FONT_10X14) ? 4U : 8U;
+  uint8_t columns = (displayDevice->font == SSD13XX_FONT_10X14) ? 10U : 21U;
+  uint8_t rows = (displayDevice->font == SSD13XX_FONT_10X14) ? 4U : 8U;
 
   if (character == '\n') {
     displayColumn = 0U;
@@ -161,7 +167,7 @@ static ErrorStatus ssd13xx_SendCommands(
   uint8_t buffer[32];
   buffer[0] = SSD13XX_COMMAND_CONTROL;
   for (uint8_t i = 0U; i < length; i++) buffer[i + 1U] = commands[i];
-  return I2C_Master_Send(device->I2C, device->Address, buffer, length + 1U);
+  return I2C_Master_Send(device->i2c, device->address, buffer, length + 1U);
 }
 
 
@@ -192,7 +198,7 @@ static ErrorStatus ssd13xx_ClearTextRow(
   SSD13xx_TypeDef* device,
   uint8_t row
 ) {
-  uint8_t pageCount = (device->Font == SSD13XX_FONT_10X14) ? 2U : 1U;
+  uint8_t pageCount = (device->font == SSD13XX_FONT_10X14) ? 2U : 1U;
   uint8_t firstPage = row * pageCount;
   ErrorStatus status = ssd13xx_SetWindow(
     device,
@@ -206,8 +212,8 @@ static ErrorStatus ssd13xx_ClearTextRow(
   uint8_t blocks = 8U * pageCount;
   for (uint8_t i = 0U; (i < blocks) && (status == SUCCESS); i++) {
     status = I2C_Master_Send(
-      device->I2C,
-      device->Address,
+      device->i2c,
+      device->address,
       clearBuffer,
       sizeof(clearBuffer)
     );
@@ -229,7 +235,7 @@ static ErrorStatus ssd13xx_WriteCharacter(
   uint8_t glyphIndex = ssd13xx_FontIndex(character);
 
   glyphBuffer[0] = SSD13XX_DATA_CONTROL;
-  if (device->Font == SSD13XX_FONT_10X14) {
+  if (device->font == SSD13XX_FONT_10X14) {
     glyphLength = sizeof(font_dot_10x14_t);
     pageCount = 2U;
     for (uint8_t i = 0U; i < glyphLength; i++) {
@@ -256,8 +262,8 @@ static ErrorStatus ssd13xx_WriteCharacter(
   );
   if (status != SUCCESS) return (ERROR);
   return I2C_Master_Send(
-    device->I2C,
-    device->Address,
+    device->i2c,
+    device->address,
     glyphBuffer,
     glyphLength + 1U
   );

--- a/Periph/Src/usart.c
+++ b/Periph/Src/usart.c
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : usart.c
-  * @brief          : This file contains the common defines for the USART 
-  *                   initialization functions.
+  * @brief          : USART peripheral implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 02:40:44 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  

--- a/Periph/Src/whxxxx.c
+++ b/Periph/Src/whxxxx.c
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : whxxxx.c
-  * @brief          : WHxxxx character display interface over an I2C backpack.
+  * @brief          : WHxxxx character display implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 04:51:32 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -80,20 +86,20 @@ ErrorStatus WHxxxx_Init(I2C_TypeDef* i2c, uint8_t address) {
   displayMutex = xSemaphoreCreateMutexStatic(&displayMutexBuffer);
   if (displayMutex == NULL) return (ERROR);
 
-  _delay_ms(40U);
+  Delay_Milliseconds(40U);
   if (whxxxx_WriteNibble(0x30U, 0U) != SUCCESS) return (ERROR);
-  _delay_us(4100U);
+  Delay_Microseconds(4100U);
   if (whxxxx_WriteNibble(0x30U, 0U) != SUCCESS) return (ERROR);
-  _delay_us(100U);
+  Delay_Microseconds(100U);
   if (whxxxx_WriteNibble(0x30U, 0U) != SUCCESS) return (ERROR);
-  _delay_us(40U);
+  Delay_Microseconds(40U);
   if (whxxxx_WriteNibble(0x20U, 0U) != SUCCESS) return (ERROR);
-  _delay_us(40U);
+  Delay_Microseconds(40U);
 
   if (whxxxx_Command(WHXXXX_FUNCTION_SET) != SUCCESS) return (ERROR);
   if (whxxxx_Command(0x0CU) != SUCCESS) return (ERROR); /* Display on, cursor off */
   if (whxxxx_Command(0x01U) != SUCCESS) return (ERROR); /* Clear display */
-  _delay_us(1640U);
+  Delay_Microseconds(1640U);
   if (whxxxx_Command(0x06U) != SUCCESS) return (ERROR); /* Increment cursor */
 
   displayReady = ENABLE;
@@ -109,7 +115,7 @@ ErrorStatus WHxxxx_Clear(void) {
   if (whxxxx_Lock() != SUCCESS) return (ERROR);
   ErrorStatus status = whxxxx_Command(0x01U);
   if (status == SUCCESS) {
-    _delay_us(1640U);
+    Delay_Microseconds(1640U);
     displayRow = 0U;
     displayColumn = 0U;
     displayNewLinePending = DISABLE;
@@ -150,7 +156,7 @@ ErrorStatus WHxxxx_Print(const uint8_t* buffer, uint16_t length) {
 
 
 // -------------------------------------------------------------
-int putc_dspl_wh(char character) {
+int WHxxxx_PutChar(char character) {
   if ((displayReady != ENABLE) || (displayI2C == NULL) || (displayMutex == NULL)) {
     return (ERROR);
   }
@@ -163,7 +169,7 @@ int putc_dspl_wh(char character) {
   } else if (character != '\r') {
     if (displayNewLinePending == ENABLE) {
       status = whxxxx_Command(0x01U);
-      _delay_us(1640U);
+      Delay_Microseconds(1640U);
       displayRow = 0U;
       displayColumn = 0U;
       displayNewLinePending = DISABLE;
@@ -223,7 +229,7 @@ static ErrorStatus whxxxx_WriteByte(uint8_t value, uint8_t flags) {
   bytes[2] = low | WHXXXX_ENABLE;
   bytes[3] = low;
   ErrorStatus status = I2C_Master_Send(displayI2C, displayAddress, bytes, sizeof(bytes));
-  _delay_us(40U);
+  Delay_Microseconds(40U);
   return (status);
 }
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 * TCP measurement service on port 5005
 * TCP sensor information and health service on port 5006
 
+### Development documentation
+
+* [Naming conventions](docs/NAMING_CONVENTIONS.md)
+
 ### TCP measurement commands
 
 Measurement commands listen on TCP port 5005. Commands may be terminated with
@@ -132,4 +136,4 @@ OK t:4,h:2,p:2,all:4
 
 ---
 
-&copy; 2017-2025, Askug Ltd., Dmitry Slobodchikov
+&copy; 2017-2026, Askug Ltd., Dmitry Slobodchikov

--- a/Srv/Inc/health_service.h
+++ b/Srv/Inc/health_service.h
@@ -43,11 +43,11 @@ void HealthService_Register(HealthComponent_TypeDef);
 void HealthService_Report(HealthComponent_TypeDef);
 
 /**
-  * @brief Latch an emergency condition and stop reloading the watchdog.
+  * @brief Latch a system failure and stop reloading the watchdog.
   *
   * The IWDG timeout is nominally 2.4 seconds. The recovery target remains
   * within four seconds after allowing for the uncalibrated LSI tolerance.
   */
-void System_Error(void);
+void HealthService_LatchFailure(void);
 
 #endif /* __HEALTH_SERVICE_H */

--- a/Srv/Inc/health_service.h
+++ b/Srv/Inc/health_service.h
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : health_service.h
-  * @brief          : Internal health supervision and watchdog service.
+  * @brief          : Internal health supervision and watchdog service interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 07:44:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -10,22 +16,38 @@
 
 #include "main.h"
 
+/**
+  * @brief Bit mask identifying services supervised by the health service.
+  */
 typedef enum {
   HEALTH_COMPONENT_HEART_BEAT  = (1UL << 0U),
   HEALTH_COMPONENT_TEMPERATURE = (1UL << 1U),
   HEALTH_COMPONENT_TCP         = (1UL << 2U)
 } HealthComponent_TypeDef;
 
+/**
+  * @brief Create the internal health supervision task.
+  */
 void HealthService_Init(void);
+
+/**
+  * @brief Add a component to the set required by each self-check round.
+  * @param component (HealthComponent_TypeDef) Component bit to register.
+  */
 void HealthService_Register(HealthComponent_TypeDef);
+
+/**
+  * @brief Report forward progress by a registered component.
+  * @param component (HealthComponent_TypeDef) Component bit to report.
+  */
 void HealthService_Report(HealthComponent_TypeDef);
 
 /**
- * @brief Latch an emergency condition and stop reloading the watchdog.
- *
- * The IWDG timeout is nominally 2.4 seconds. The recovery target remains
- * within four seconds after allowing for the uncalibrated LSI tolerance.
- */
-void system_error(void);
+  * @brief Latch an emergency condition and stop reloading the watchdog.
+  *
+  * The IWDG timeout is nominally 2.4 seconds. The recovery target remains
+  * within four seconds after allowing for the uncalibrated LSI tolerance.
+  */
+void System_Error(void);
 
 #endif /* __HEALTH_SERVICE_H */

--- a/Srv/Inc/heart_beat.h
+++ b/Srv/Inc/heart_beat.h
@@ -1,12 +1,13 @@
 /**
   ******************************************************************************
   * @file           : heart_beat.h
-  * @brief          : Header for heart_beat.c file.
-  *                   This file contains the common defines for LED blinking 
-  *                   that represent the system health.
+  * @brief          : Heartbeat LED service interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 02:40:44 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -29,11 +30,9 @@
 /* Exported functions prototypes ---------------------------------------------*/
 
 /**
-  * @brief  Heartbeat LED blinking service
-  * @param  none
-  * @retval none
- */
-void HeartBeatService(void);
+  * @brief Create the task that displays system activity on the heartbeat LED.
+  */
+void HeartBeatService_Init(void);
 
 
 #ifdef __cplusplus

--- a/Srv/Inc/tcp_service.h
+++ b/Srv/Inc/tcp_service.h
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : tcp_service.h
   * @brief          : TCP command service interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 01:34:04 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -18,7 +24,9 @@ extern "C" {
 void TcpCommandService_Init(void);
 
 /**
-  * @brief Advances the non-blocking TCP command server state machine.
+  * @brief Advance the non-blocking measurement TCP server state machine.
+  *
+  * This function is called by the TCP service task and operates on port 5005.
   */
 void TcpCommandService_Run(void);
 

--- a/Srv/Inc/temperature_service.h
+++ b/Srv/Inc/temperature_service.h
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : temperature_service.h
-  * @brief          : Periodic temperature sensor service.
+  * @brief          : Periodic environmental sensor service interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -13,6 +19,9 @@
 #define SENSOR_SERVICE_MAX_DS18B20 6U
 #define SENSOR_SERVICE_MAX_DEVICES (SENSOR_SERVICE_MAX_DS18B20 + 2U)
 
+/**
+  * @brief Models supported by the periodic sensor service.
+  */
 typedef enum {
   SENSOR_MODEL_DS18B20 = 0U,
   SENSOR_MODEL_BMP280,
@@ -20,12 +29,18 @@ typedef enum {
   SENSOR_MODEL_BME680
 } SensorModel_TypeDef;
 
+/**
+  * @brief Measurement capabilities exposed by a sensor.
+  */
 typedef enum {
   SENSOR_CAPABILITY_TEMPERATURE = (1U << 0U),
   SENSOR_CAPABILITY_PRESSURE    = (1U << 1U),
   SENSOR_CAPABILITY_HUMIDITY    = (1U << 2U)
 } SensorCapability_TypeDef;
 
+/**
+  * @brief Availability and health states derived from periodic measurements.
+  */
 typedef enum {
   SENSOR_HEALTH_INITIALIZING = 0U,
   SENSOR_HEALTH_HEALTHY,
@@ -35,6 +50,9 @@ typedef enum {
   SENSOR_HEALTH_MISSING
 } SensorHealthState_TypeDef;
 
+/**
+  * @brief Errors recorded for the latest unsuccessful measurement.
+  */
 typedef enum {
   SENSOR_ERROR_NONE = 0U,
   SENSOR_ERROR_NOT_READY,
@@ -45,6 +63,22 @@ typedef enum {
   SENSOR_ERROR_CONVERSION
 } SensorError_TypeDef;
 
+/**
+  * @brief Cached identity, measurements, and health for one physical sensor.
+  * @param model (SensorModel_TypeDef) Detected sensor model.
+  * @param capabilities (uint8_t) Bit mask of SensorCapability_TypeDef values.
+  * @param identity (uint8_t[8]) DS18B20 ROM code; zero for Bosch sensors.
+  * @param serialNumber (uint32_t) Bosch unique ID; zero for DS18B20 sensors.
+  * @param dataValid (BaseType_t) Whether cached measurements may be returned.
+  * @param temperature (int32_t) Temperature in hundredths of a degree Celsius.
+  * @param pressure (uint32_t) Pressure in pascals.
+  * @param humidity (uint32_t) Relative humidity in thousandths of percent.
+  * @param lastAttempt (TickType_t) Tick of the latest measurement attempt.
+  * @param lastSuccess (TickType_t) Tick of the latest successful measurement.
+  * @param consecutiveFailures (uint16_t) Failures since the last success.
+  * @param health (SensorHealthState_TypeDef) Derived sensor health state.
+  * @param lastError (SensorError_TypeDef) Latest measurement error.
+  */
 typedef struct {
   SensorModel_TypeDef model;
   uint8_t capabilities;
@@ -61,6 +95,13 @@ typedef struct {
   SensorError_TypeDef lastError;
 } SensorSnapshot_TypeDef;
 
+/**
+  * @brief Number of registered sensors grouped by measurement capability.
+  * @param temperature (uint8_t) Sensors that measure temperature.
+  * @param pressure (uint8_t) Sensors that measure pressure.
+  * @param humidity (uint8_t) Sensors that measure relative humidity.
+  * @param all (uint8_t) All registered physical sensors.
+  */
 typedef struct {
   uint8_t temperature;
   uint8_t pressure;
@@ -68,8 +109,23 @@ typedef struct {
   uint8_t all;
 } SensorCounts_TypeDef;
 
+/**
+  * @brief Detect supported sensors and create the periodic measurement task.
+  */
 void TemperatureSensorService_Init(void);
+
+/**
+  * @brief Return counts of registered sensors by capability.
+  * @param counts (SensorCounts_TypeDef*) Destination for the counts.
+  */
 void TemperatureSensorService_GetCounts(SensorCounts_TypeDef*);
+
+/**
+  * @brief Copy the cached snapshot for a physical sensor number.
+  * @param sensorNumber (uint8_t) One-based physical sensor number.
+  * @param snapshot (SensorSnapshot_TypeDef*) Destination for the snapshot.
+  * @retval (ErrorStatus) SUCCESS when the sensor number is registered.
+  */
 ErrorStatus TemperatureSensorService_GetSnapshot(
   uint8_t,
   SensorSnapshot_TypeDef*

--- a/Srv/Src/health_service.c
+++ b/Srv/Src/health_service.c
@@ -2,6 +2,12 @@
   ******************************************************************************
   * @file           : health_service.c
   * @brief          : Internal health supervision and watchdog service.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 25.07.2026 07:44:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -61,7 +67,7 @@ void HealthService_Report(HealthComponent_TypeDef component) {
 
 
 // -------------------------------------------------------------
-void system_error(void) {
+void System_Error(void) {
   emergencyLatched = pdTRUE;
 }
 
@@ -95,7 +101,7 @@ static void healthService_Task(void* parameters) {
           "Self-check: FAILED, missing:0x%08lx\n",
           (unsigned long)(expected & ~observed)
         );
-        system_error();
+        System_Error();
       } else {
         printf("Self-check: OK\n");
       }

--- a/Srv/Src/health_service.c
+++ b/Srv/Src/health_service.c
@@ -67,7 +67,7 @@ void HealthService_Report(HealthComponent_TypeDef component) {
 
 
 // -------------------------------------------------------------
-void System_Error(void) {
+void HealthService_LatchFailure(void) {
   emergencyLatched = pdTRUE;
 }
 
@@ -101,7 +101,7 @@ static void healthService_Task(void* parameters) {
           "Self-check: FAILED, missing:0x%08lx\n",
           (unsigned long)(expected & ~observed)
         );
-        System_Error();
+        HealthService_LatchFailure();
       } else {
         printf("Self-check: OK\n");
       }

--- a/Srv/Src/heart_beat.c
+++ b/Srv/Src/heart_beat.c
@@ -1,11 +1,13 @@
 /**
   ******************************************************************************
   * @file           : heart_beat.c
-  *                   This file contains the LED blinking code that represent 
-  *                   the system health.
+  * @brief          : Heartbeat LED service implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 22.09.2025 04:30:00 PM
   ******************************************************************************
   * @attention
-  *
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
  
@@ -35,7 +37,7 @@ static void heartBeat_Blink(GPIO_TypeDef*, uint16_t, void (*)(TickType_t), TickT
 
 /*******************************************************************************/
 
-void HeartBeatService(void) {
+void HeartBeatService_Init(void) {
 
   static StaticTask_t heartBeatTaskTCB;
   static StackType_t heartBeatTaskStack[configMINIMAL_STACK_SIZE];

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : tcp_service.c
-  * @brief          : TCP command service on port 5005.
+  * @brief          : TCP measurement and sensor-information services.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 01:34:04 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -302,6 +308,7 @@ static void tcpCommandService_ProcessCommand(const uint8_t* command, uint16_t le
   char response[TCP_RESPONSE_SIZE];
   size_t used = 0U;
 
+  /** @brief Measurement command selected from the received TCP prefix. */
   typedef enum {
     TCP_SENSOR_COMMAND_NONE = 0U,
     TCP_SENSOR_COMMAND_ALL,
@@ -442,6 +449,7 @@ static void tcpHealthService_ProcessCommand(
     return;
   }
 
+  /** @brief Information command selected from the received TCP prefix. */
   typedef enum {
     TCP_INFO_COMMAND_NONE = 0U,
     TCP_INFO_COMMAND_MODEL,

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -1,7 +1,13 @@
 /**
   ******************************************************************************
   * @file           : temperature_service.c
-  * @brief          : Sequential periodic temperature sensor service.
+  * @brief          : Sequential periodic environmental sensor service.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 24.07.2026 10:05:16 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
   ******************************************************************************
   */
 
@@ -61,20 +67,20 @@ static void temperatureSensorService_PrintCentiDegrees(int32_t);
 
 // -------------------------------------------------------------
 void TemperatureSensorService_Init(void) {
-  if (!FLAG_CHECK(_PREG_, _PR_I2C1_BUS)) {
-    if (BMx280_Init(Get_BoschDevice(BMX280_MODEL)) != SUCCESS) {
-      FLAG_SET(_PREG_, _PR_BMX280);
+  if (!FLAG_CHECK(peripheralReadiness, PERIPHERAL_I2C1_ERROR_BIT)) {
+    if (BMx280_Init(BMxX80_GetDevice(BMX280_MODEL)) != SUCCESS) {
+      FLAG_SET(peripheralReadiness, PERIPHERAL_BMX280_ERROR_BIT);
     } else {
       bmx280Registered = pdTRUE;
     }
-    if (BMx680_Init(Get_BoschDevice(BMX680_MODEL)) != SUCCESS) {
-      FLAG_SET(_PREG_, _PR_BMX680);
+    if (BMx680_Init(BMxX80_GetDevice(BMX680_MODEL)) != SUCCESS) {
+      FLAG_SET(peripheralReadiness, PERIPHERAL_BMX680_ERROR_BIT);
     } else {
       bmx680Registered = pdTRUE;
     }
   } else {
-    FLAG_SET(_PREG_, _PR_BMX280);
-    FLAG_SET(_PREG_, _PR_BMX680);
+    FLAG_SET(peripheralReadiness, PERIPHERAL_BMX280_ERROR_BIT);
+    FLAG_SET(peripheralReadiness, PERIPHERAL_BMX680_ERROR_BIT);
   }
 
   static StaticTask_t taskControlBlock;
@@ -194,10 +200,10 @@ static ErrorStatus temperatureSensorService_MeasureDs18b20(
 
 // -------------------------------------------------------------
 static ErrorStatus temperatureSensorService_MeasureBmx280(void) {
-  if (FLAG_CHECK(_PREG_, _PR_BMX280)) return (ERROR);
+  if (FLAG_CHECK(peripheralReadiness, PERIPHERAL_BMX280_ERROR_BIT)) return (ERROR);
 
-  BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
-  return BMx280_Measurement(device);
+  BMxX80_TypeDef* device = BMxX80_GetDevice(BMX280_MODEL);
+  return BMx280_Measure(device);
 }
 
 
@@ -205,10 +211,10 @@ static ErrorStatus temperatureSensorService_MeasureBmx280(void) {
 
 // -------------------------------------------------------------
 static ErrorStatus temperatureSensorService_MeasureBmx680(void) {
-  if (FLAG_CHECK(_PREG_, _PR_BMX680)) return (ERROR);
+  if (FLAG_CHECK(peripheralReadiness, PERIPHERAL_BMX680_ERROR_BIT)) return (ERROR);
 
-  BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
-  return BMx680_Measurement(device);
+  BMxX80_TypeDef* device = BMxX80_GetDevice(BMX680_MODEL);
+  return BMx680_Measure(device);
 }
 
 
@@ -274,28 +280,28 @@ static void temperatureSensorService_UpdateSnapshots(
   }
 
   if (bmx280Registered == pdTRUE) {
-    BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
+    BMxX80_TypeDef* device = BMxX80_GetDevice(BMX280_MODEL);
     int8_t index = temperatureSensorService_FindModel(
-      (device->DevID == BME280_ID) ? SENSOR_MODEL_BME280 : SENSOR_MODEL_BMP280
+      (device->deviceId == BME280_ID) ? SENSOR_MODEL_BME280 : SENSOR_MODEL_BMP280
     );
     if ((index < 0) && (sensorSnapshotCount < SENSOR_SERVICE_MAX_DEVICES)) {
       index = (int8_t)sensorSnapshotCount++;
       sensorSnapshots[index] = (SensorSnapshot_TypeDef){
-        .model = (device->DevID == BME280_ID)
+        .model = (device->deviceId == BME280_ID)
           ? SENSOR_MODEL_BME280
           : SENSOR_MODEL_BMP280,
         .capabilities = SENSOR_CAPABILITY_TEMPERATURE
           | SENSOR_CAPABILITY_PRESSURE
-          | ((device->DevID == BME280_ID) ? SENSOR_CAPABILITY_HUMIDITY : 0U),
+          | ((device->deviceId == BME280_ID) ? SENSOR_CAPABILITY_HUMIDITY : 0U),
         .health = SENSOR_HEALTH_INITIALIZING,
         .lastError = SENSOR_ERROR_NOT_READY
       };
-      sensorSnapshots[index].serialNumber = device->UniqueID;
+      sensorSnapshots[index].serialNumber = device->uniqueId;
     }
     if (index >= 0) {
-      sensorSnapshots[index].temperature = device->Results.temperature;
-      sensorSnapshots[index].pressure = device->Results.pressure;
-      sensorSnapshots[index].humidity = device->Results.humidity;
+      sensorSnapshots[index].temperature = device->results.temperature;
+      sensorSnapshots[index].pressure = device->results.pressure;
+      sensorSnapshots[index].humidity = device->results.humidity;
       temperatureSensorService_RecordResult(
         &sensorSnapshots[index],
         bmx280Status,
@@ -306,7 +312,7 @@ static void temperatureSensorService_UpdateSnapshots(
   }
 
   if (bmx680Registered == pdTRUE) {
-    BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
+    BMxX80_TypeDef* device = BMxX80_GetDevice(BMX680_MODEL);
     int8_t index = temperatureSensorService_FindModel(SENSOR_MODEL_BME680);
     if ((index < 0) && (sensorSnapshotCount < SENSOR_SERVICE_MAX_DEVICES)) {
       index = (int8_t)sensorSnapshotCount++;
@@ -318,12 +324,12 @@ static void temperatureSensorService_UpdateSnapshots(
         .health = SENSOR_HEALTH_INITIALIZING,
         .lastError = SENSOR_ERROR_NOT_READY
       };
-      sensorSnapshots[index].serialNumber = device->UniqueID;
+      sensorSnapshots[index].serialNumber = device->uniqueId;
     }
     if (index >= 0) {
-      sensorSnapshots[index].temperature = device->Results.temperature;
-      sensorSnapshots[index].pressure = device->Results.pressure;
-      sensorSnapshots[index].humidity = device->Results.humidity;
+      sensorSnapshots[index].temperature = device->results.temperature;
+      sensorSnapshots[index].pressure = device->results.pressure;
+      sensorSnapshots[index].humidity = device->results.humidity;
       temperatureSensorService_RecordResult(
         &sensorSnapshots[index],
         bmx680Status,
@@ -451,15 +457,15 @@ static void temperatureSensorService_PrintMeasurements(
   printf("\n");
 
   if (bmx280Status == SUCCESS) {
-    BMxX80_TypeDef* device = Get_BoschDevice(BMX280_MODEL);
-    printf((device->DevID == BME280_ID) ? "BME280: " : "BMP280: ");
-    temperatureSensorService_PrintCentiDegrees(device->Results.temperature);
-    printf(" C, %lu Pa", (unsigned long)device->Results.pressure);
-    if (device->DevID == BME280_ID) {
+    BMxX80_TypeDef* device = BMxX80_GetDevice(BMX280_MODEL);
+    printf((device->deviceId == BME280_ID) ? "BME280: " : "BMP280: ");
+    temperatureSensorService_PrintCentiDegrees(device->results.temperature);
+    printf(" C, %lu Pa", (unsigned long)device->results.pressure);
+    if (device->deviceId == BME280_ID) {
       printf(
         ", %lu.%03lu %%RH",
-        (unsigned long)(device->Results.humidity / 1000U),
-        (unsigned long)(device->Results.humidity % 1000U)
+        (unsigned long)(device->results.humidity / 1000U),
+        (unsigned long)(device->results.humidity % 1000U)
       );
     }
   } else {
@@ -468,14 +474,14 @@ static void temperatureSensorService_PrintMeasurements(
   printf("\n");
 
   if (bmx680Status == SUCCESS) {
-    BMxX80_TypeDef* device = Get_BoschDevice(BMX680_MODEL);
+    BMxX80_TypeDef* device = BMxX80_GetDevice(BMX680_MODEL);
     printf("BME680: ");
-    temperatureSensorService_PrintCentiDegrees(device->Results.temperature);
+    temperatureSensorService_PrintCentiDegrees(device->results.temperature);
     printf(
       " C, %lu Pa, %lu.%03lu %%RH",
-      (unsigned long)device->Results.pressure,
-      (unsigned long)(device->Results.humidity / 1000U),
-      (unsigned long)(device->Results.humidity % 1000U)
+      (unsigned long)device->results.pressure,
+      (unsigned long)(device->results.humidity / 1000U),
+      (unsigned long)(device->results.humidity % 1000U)
     );
   } else {
     printf("BME680: conversion error");

--- a/docs/NAMING_CONVENTIONS.md
+++ b/docs/NAMING_CONVENTIONS.md
@@ -1,0 +1,108 @@
+# Naming conventions
+
+This document defines the preferred naming style for project-owned code in
+`Core`, `Periph`, `Srv`, and the project-specific Ethernet integration.
+Imported FreeRTOS, CMSIS, ST, and WIZnet code keeps its upstream style.
+
+The conventions describe the target style. Existing names are changed only in
+dedicated refactoring work, because renaming an API can affect several modules.
+
+## General rules
+
+- Use English names that describe purpose rather than implementation detail.
+- Spell out words unless an abbreviation is established in the hardware or
+  protocol documentation.
+- Keep hardware names in their canonical form: `DS18B20`, `I2C`, `IWDG`,
+  `SPI`, `SSD13xx`, `TCP`, and `W5500`.
+- Include units in names when the type alone does not make them clear, for
+  example `periodMs`, `temperatureCentiDegrees`, or `humidityMilliPercent`.
+- Avoid new identifiers beginning with an underscore. C reserves several such
+  forms for the implementation.
+- Use one term consistently for one concept. Prefer `Init`, `Read`, `Write`,
+  `Measure`, `Get`, `Set`, `Lock`, `Unlock`, `Register`, and `Report`.
+
+## Files and modules
+
+- Use lowercase `snake_case` file names: `health_service.c`.
+- Give a public header the same base name as its implementation file.
+- Peripheral drivers belong in `Periph`; FreeRTOS-based application services
+  belong in `Srv`; startup and application-wide facilities belong in `Core`.
+
+## Functions
+
+- Public functions use `PascalCase` with a module prefix:
+  `HealthService_Init`, `I2C_Master_Send`, `DS18B20_Measure`.
+- Private functions use `camelCase` with a module prefix:
+  `healthService_WatchdogReload`.
+- Use an underscore between the module name and the operation for new public
+  APIs.
+- Use verbs for operations and nouns only for accessors that return an object.
+- An `Init` function initializes hardware or creates a service and does not
+  perform periodic work.
+- A `Get` function does not transfer ownership of returned storage unless its
+  documentation explicitly says otherwise.
+- Boolean predicates should begin with `Is`, `Has`, or `Can`.
+
+## Types and enumerators
+
+- Public typedef names use `PascalCase` and end in `_TypeDef`:
+  `SensorSnapshot_TypeDef`.
+- Structure names describe one object; collection names describe the contained
+  set.
+- Enum constants and bit flags use uppercase `SNAKE_CASE` with a module prefix:
+  `SENSOR_HEALTH_FAILED`.
+- Structure members and function parameters use `camelCase`.
+- New code should not introduce `_t` typedef names because POSIX reserves many
+  names with that suffix. Existing Bosch calibration types can be migrated in
+  a separate compatibility-aware refactor.
+
+## Variables and constants
+
+- Local variables and parameters use `camelCase`.
+- File-local variables use `camelCase`; their `static` storage already conveys
+  privacy.
+- Compile-time constants and macros use uppercase `SNAKE_CASE`.
+- Macros that behave like functions use uppercase `SNAKE_CASE` and parenthesize
+  every parameter and the complete expression.
+- FreeRTOS handles should identify the owned object, for example
+  `healthTaskHandle` or `i2cMutex`.
+
+## Documentation
+
+Document every project-owned function where it is declared. Document a private
+function immediately above its definition or prototype. Do not duplicate a
+complete public API description in both the header and source file.
+
+Function documentation uses this form:
+
+```c
+/**
+  * @brief Convert and read every discovered DS18B20 sensor.
+  * @param measurements (DS18B20_Measurement_TypeDef*) Output array.
+  * @param capacity (uint8_t) Number of elements available in the array.
+  * @param count (uint8_t*) Number of entries written.
+  * @retval (ErrorStatus) SUCCESS when at least one device was reported.
+  */
+```
+
+Use `@param` only for real parameters; omit it for a `void` parameter list.
+Use `@retval` only for functions that return a value. State units, ownership,
+valid ranges, nullability, blocking behavior, and task/interrupt restrictions
+when they matter.
+
+Structure documentation lists the purpose and meaning of every member:
+
+```c
+/**
+  * @brief Cached measurement and health information for one sensor.
+  * @param model (SensorModel_TypeDef) Detected sensor model.
+  * @param temperature (int32_t) Temperature in hundredths of a degree Celsius.
+  */
+```
+
+## Compatibility notes
+
+Issue #23 aligns project-owned identifiers with this convention. Imported
+libraries retain their upstream APIs even where their style differs. Bosch
+calibration members such as `dig_t1` and `par_p1` also retain the datasheet
+spelling so the compensation formulas remain directly traceable.


### PR DESCRIPTION
## Summary

- document public APIs, structures, and enums with Doxygen comments
- standardize authentic source-file headers with project metadata
- align identifiers with the project naming conventions
- move common delay and bit-band APIs into common.h
- add and link the project naming-conventions document
- remove the obsolete putc_dspl declaration while retaining the overridable System_ErrorHandler hook

## Verification

- firmware build completed successfully
- target-device build was tested by the project owner

Closes #23