### PR TITLE
Issue #25: Implement HTTP resource health monitoring

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -55,6 +55,7 @@ extern "C" {
 #include "health_service.h"
 #include "temperature_service.h"
 #include "tcp_service.h"
+#include "http_monitor_service.h"
 
 #include "wizchip_port.h"
 

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -43,6 +43,7 @@ extern "C" {
 #include "usart.h"
 #include "onewire.h"
 #include "spi.h"
+#include "w25qxx.h"
 #include "i2c.h"
 #include "whxxxx.h"
 #include "ssd13xx.h"
@@ -73,6 +74,8 @@ extern __IO uint32_t peripheralReadiness;
 #define PERIPHERAL_BMX280_ERROR_BIT        6
 #define PERIPHERAL_BMX680_ERROR_BIT        7
 #define PERIPHERAL_SSD_DISPLAY_ERROR_BIT   8
+#define PERIPHERAL_SPI2_ERROR_BIT          9
+#define PERIPHERAL_W25Q64_ERROR_BIT        10
 
 #ifdef __cplusplus
 }

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -40,6 +40,7 @@ extern "C" {
 #include "project_config.h"
 
 #include "gpio.h"
+#include "buzzer.h"
 #include "usart.h"
 #include "onewire.h"
 #include "spi.h"
@@ -76,6 +77,7 @@ extern __IO uint32_t peripheralReadiness;
 #define PERIPHERAL_SSD_DISPLAY_ERROR_BIT   8
 #define PERIPHERAL_SPI2_ERROR_BIT          9
 #define PERIPHERAL_W25Q64_ERROR_BIT        10
+#define PERIPHERAL_BUZZER_ERROR_BIT        11
 
 #ifdef __cplusplus
 }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -35,6 +35,9 @@ int main(void) {
 
   /* Initialization of necessary peripherals */
   if (LED_Init(HEARTBEAT_PORT, HEARTBEAT_PIN) != SUCCESS) FLAG_SET(peripheralReadiness, PERIPHERAL_HEARTBEAT_LED_ERROR_BIT);
+  if ((Buzzer_Init() != SUCCESS) || (Buzzer_SelfTest() != SUCCESS)) {
+    FLAG_SET(peripheralReadiness, PERIPHERAL_BUZZER_ERROR_BIT);
+  }
   if (OneWire_Init(ONEWIRE_PORT, ONEWIRE_PIN) != SUCCESS) FLAG_SET(peripheralReadiness, PERIPHERAL_ONEWIRE_ERROR_BIT);
   if (USART_Init(USART1) != SUCCESS) FLAG_SET(peripheralReadiness, PERIPHERAL_USART1_ERROR_BIT);
   if ((SPI_Init(SPI1) != SUCCESS)
@@ -248,6 +251,7 @@ void SystemInit (void) {
     | RCC_APB2ENR_IOPCEN
     | RCC_APB2ENR_USART1EN
     | RCC_APB2ENR_SPI1EN
+    | RCC_APB2ENR_TIM1EN
   ));
 
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -89,6 +89,7 @@ int main(void) {
   /* TCP command service */
   if (!FLAG_CHECK(peripheralReadiness, PERIPHERAL_SPI1_ERROR_BIT)) {
     TcpCommandService_Init();
+    HttpMonitorService_Init();
   }
 
   /* Run the internal health and watchdog service last. */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -43,6 +43,12 @@ int main(void) {
       || (SPI_AdjustConfiguration(SPI1) != SUCCESS)) {
     FLAG_SET(peripheralReadiness, PERIPHERAL_SPI1_ERROR_BIT);
   }
+  if ((SPI_Init(SPI2) != SUCCESS)
+      || (SPI_AdjustConfiguration(SPI2) != SUCCESS)) {
+    FLAG_SET(peripheralReadiness, PERIPHERAL_SPI2_ERROR_BIT);
+  } else if (W25Qxx_Init() != SUCCESS) {
+    FLAG_SET(peripheralReadiness, PERIPHERAL_W25Q64_ERROR_BIT);
+  }
   if (I2C_Init(I2C1) != SUCCESS) {
     FLAG_SET(peripheralReadiness, PERIPHERAL_I2C1_ERROR_BIT);
   } else {
@@ -230,7 +236,10 @@ void SystemInit (void) {
   ));
 
   /* APB1 peripherals */
-  SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C1EN);
+  SET_BIT(RCC->APB1ENR, (
+      RCC_APB1ENR_I2C1EN
+    | RCC_APB1ENR_SPI2EN
+  ));
 
   /* APB2 peripherals */
   SET_BIT(RCC->APB2ENR, (

--- a/Ethernet/DNS/dns.c
+++ b/Ethernet/DNS/dns.c
@@ -118,7 +118,7 @@ uint8_t* pDNSMSG;       // DNS message buffer
 uint8_t  DNS_SOCKET;    // SOCKET number for DNS
 uint16_t DNS_MSGID;     // DNS message ID
 
-uint32_t dns_1s_tick;   // for timout of DNS processing
+volatile uint32_t dns_1s_tick;   // for timeout of DNS processing
 static uint8_t retry_count;
 
 /* converts uint16_t from network buffer to a host byte order integer. */

--- a/Ethernet/wizchip_port.c
+++ b/Ethernet/wizchip_port.c
@@ -1,182 +1,277 @@
-/*
- * wizchip_port.c
- *
- *  Created on: Oct 27, 2025
- *      Author: controllerstech
- */
+/**
+  ******************************************************************************
+  * @file           : wizchip_port.c
+  * @brief          : W5500 board integration and network configuration.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.10.2025
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
 
 #include "main.h"
 #include "wizchip_conf.h"
-#include "stdio.h"
-#include "string.h"
 #include "socket.h"
-#include "stdbool.h"
 #include "DHCP/dhcp.h"
 #include "DNS/dns.h"
+#include <stdbool.h>
+#include <string.h>
 
-#define USE_DHCP  1
+#define W5500_USE_DHCP             1U
+#define W5500_DHCP_SOCKET          7U
+#define W5500_DNS_SOCKET           6U
+#define W5500_DHCP_RETRIES        20U
+#define W5500_LINK_RETRIES        10U
+#define W5500_DHCP_BUFFER_SIZE    548U
 
-wiz_NetInfo netInfo = {
-    .mac = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
-    .ip = {192, 168, 1, 10},
-    .sn = {255, 255, 255, 0},
-    .gw = {192, 168, 1, 1},
-    .dns = {8, 8, 8, 8},
-#if USE_DHCP
-	.dhcp = NETINFO_DHCP
+#define W5500_ERROR_MUTEX          -1
+#define W5500_ERROR_CHIP_INIT      -2
+#define W5500_ERROR_VERSION        -3
+#define W5500_ERROR_LINK            1
+
+#define W5500_SELECT()  PIN_L(ETH_CS_PORT, ETH_CS_PIN)
+#define W5500_RELEASE() PIN_H(ETH_CS_PORT, ETH_CS_PIN)
+#define W5500_RESET_L() PIN_L(ETH_RST_PORT, ETH_RST_PIN)
+#define W5500_RESET_H() PIN_H(ETH_RST_PORT, ETH_RST_PIN)
+
+static wiz_NetInfo w5500Network = {
+  .mac = {0xaaU, 0xbbU, 0xccU, 0xddU, 0xeeU, 0xffU},
+  .ip = {192U, 168U, 1U, 10U},
+  .sn = {255U, 255U, 255U, 0U},
+  .gw = {192U, 168U, 1U, 1U},
+  .dns = {8U, 8U, 8U, 8U},
+#if W5500_USE_DHCP
+  .dhcp = NETINFO_DHCP
 #else
-    .dhcp = NETINFO_STATIC
+  .dhcp = NETINFO_STATIC
 #endif
 };
 
-/*************************************************   NO Changes After This   ***************************************************************/
+static StaticSemaphore_t w5500BusMutexStorage;
+static SemaphoreHandle_t w5500BusMutex;
 
-#define W5500_CS_LOW()     PIN_L(ETH_CS_PORT, ETH_CS_PIN);
-#define W5500_CS_HIGH()    PIN_H(ETH_CS_PORT, ETH_CS_PIN);
-#define W5500_RST_LOW()    PIN_L(ETH_RST_PORT, ETH_RST_PIN);
-#define W5500_RST_HIGH()   PIN_H(ETH_RST_PORT, ETH_RST_PIN);
-
-
-// SPI transmit/receive
-void W5500_Select(void)   { W5500_CS_LOW(); }
-void W5500_Unselect(void) { W5500_CS_HIGH(); }
-
-uint8_t W5500_ReadByte(void)
-{
-    uint8_t rx;
-    SPI_Read8(SPI1, &rx, 1);
-    return rx;
-}
-
-void W5500_WriteByte(uint8_t byte)
-{
-    SPI_Write8(SPI1, &byte, 1);
-}
-
-
-#if USE_DHCP
-volatile bool ip_assigned = false;
-#define DHCP_SOCKET   7  // last available socket
-
-uint8_t DHCP_buffer[548];
-
-
-void Callback_IPAssigned(void) {
-    ip_assigned = true;
-}
-
-void Callback_IPConflict(void) {
-    ip_assigned = false;
-}
+#if W5500_USE_DHCP
+static volatile bool w5500AddressAssigned;
+static uint8_t w5500DhcpBuffer[W5500_DHCP_BUFFER_SIZE];
 #endif
 
-#define DNS_SOCKET	  6  // 2nd last socket
-uint8_t DNS_buffer[512];
+static uint8_t w5500DnsBuffer[MAX_DNS_BUF_SIZE];
 
-int W5500_Init(void)
-{
+static void w5500_Select(void);
+static void w5500_Release(void);
+static uint8_t w5500_ReadByte(void);
+static void w5500_WriteByte(uint8_t byte);
+static void w5500_Reset(void);
+static ErrorStatus w5500_CheckIdentity(void);
+static ErrorStatus w5500_WaitForLink(void);
+static void w5500_ConfigureNetwork(void);
+static void w5500_PrintNetwork(void);
 
-    SPI_Enable(SPI1);
-    
-    uint8_t memsize[2][8] = {{2,2,2,2,2,2,2,2},{2,2,2,2,2,2,2,2}};
+#if W5500_USE_DHCP
+static void w5500_AddressAssigned(void);
+static void w5500_AddressConflict(void);
+#endif
 
-    /***** Reset Sequence  *****/
-    W5500_RST_LOW();
-    // HAL_Delay(50);
-    Delay_Milliseconds(50);
-    W5500_RST_HIGH();
-    Delay_Milliseconds(200);
-    // HAL_Delay(200);
 
-    /***** Register callbacks  *****/
-    reg_wizchip_cs_cbfunc(W5500_Select, W5500_Unselect);
-    reg_wizchip_spi_cbfunc(W5500_ReadByte, W5500_WriteByte);
+// -------------------------------------------------------------
+int W5500_Init(void) {
+  static const uint8_t socketMemory[2][8] = {
+    {2U, 2U, 2U, 2U, 2U, 2U, 2U, 2U},
+    {2U, 2U, 2U, 2U, 2U, 2U, 2U, 2U}
+  };
 
-    /***** Initialize the chip  *****/
-    if (ctlwizchip(CW_INIT_WIZCHIP, (void*)memsize) == -1){
-    	printf("Error while initializing WIZCHIP\r\n");
-    	return -1;
-    }
-    printf("WIZCHIP Initialized\r\n");
+  w5500BusMutex = xSemaphoreCreateMutexStatic(&w5500BusMutexStorage);
+  if (w5500BusMutex == NULL) return (W5500_ERROR_MUTEX);
+  if (SPI_Enable(SPI1) != SUCCESS) return (W5500_ERROR_CHIP_INIT);
 
-    /***** check communication by reading Version  *****/
-    uint8_t ver = getVERSIONR();
-    if (ver != 0x04){
-    	printf("Error Communicating with W5500\t Version: 0x%02X\r\n", ver);
-    	return -2;
-    }
-    printf("Checking Link Status..\r\n");
+  w5500_Reset();
+  reg_wizchip_cs_cbfunc(w5500_Select, w5500_Release);
+  reg_wizchip_spi_cbfunc(w5500_ReadByte, w5500_WriteByte);
 
- 	/*****  CHeck Link Status  *****/
-    uint8_t link = PHY_LINK_OFF;
-    uint8_t retries = 10;
-    while ((link != PHY_LINK_ON) && (retries > 0)){
-        ctlwizchip(CW_GET_PHYLINK, &link);
-        if (link == PHY_LINK_ON) printf("Link: UP\r\n");
-        else printf("Link: DOWN Retrying : %d\r\n", 10-retries);
-        retries--;
-        // HAL_Delay(500);
-        Delay_Milliseconds(500);
-    }
-    if (link != PHY_LINK_ON){
-    	printf ("Link is Down,please reconnect and retry\nExiting Setup..\r\n");
-    	return 3;
-    }
+  if (ctlwizchip(CW_INIT_WIZCHIP, (void*)socketMemory) == -1) {
+    printf("W5500: initialization failed\n");
+    return (W5500_ERROR_CHIP_INIT);
+  }
+  if (w5500_CheckIdentity() != SUCCESS) return (W5500_ERROR_VERSION);
+  if (w5500_WaitForLink() != SUCCESS) return (W5500_ERROR_LINK);
 
-    /***** Use DHCP or Static IP  *****/
-#if USE_DHCP
-    printf ("Using DHCP.. Please Wait..\r\n");
-    setSHAR(netInfo.mac);
-    DHCP_init(DHCP_SOCKET, DHCP_buffer);
+  w5500_ConfigureNetwork();
+  DNS_init(W5500_DNS_SOCKET, w5500DnsBuffer);
+  w5500_PrintNetwork();
+  return (0);
+}
 
-    reg_dhcp_cbfunc(Callback_IPAssigned, Callback_IPAssigned, Callback_IPConflict);
 
-    retries = 20;
-    while((!ip_assigned) && (retries > 0)) {
-        DHCP_run();
-        // HAL_Delay(500);
-        Delay_Milliseconds(500);
-        retries--;
-    }
-    if(!ip_assigned) {
-    	// DHCP Failed, switch to static IP
-    	printf ("DHCP Failed, switching to static IP\r\n");
-    	ctlnetwork(CN_SET_NETINFO, (void*)&netInfo);
-    }
-    else {
-    	// if IP is allocated, read it
-        getIPfromDHCP(netInfo.ip);
-        getGWfromDHCP(netInfo.gw);
-        getSNfromDHCP(netInfo.sn);
-        getDNSfromDHCP(netInfo.dns);
 
-        // Now apply them to the chip
-        ctlnetwork(CN_SET_NETINFO, (void*)&netInfo);
-        printf("DHCP IP assigned successfully\r\n");
-    }
 
+// -------------------------------------------------------------
+void W5500_GetDnsServer(uint8_t* address) {
+  if (address == NULL) return;
+  memcpy(address, w5500Network.dns, 4U);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_Select(void) {
+  (void)xSemaphoreTake(w5500BusMutex, portMAX_DELAY);
+  W5500_SELECT();
+}
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_Release(void) {
+  W5500_RELEASE();
+  (void)xSemaphoreGive(w5500BusMutex);
+}
+
+
+
+
+// -------------------------------------------------------------
+static uint8_t w5500_ReadByte(void) {
+  uint8_t byte = 0U;
+  (void)SPI_Read8(SPI1, &byte, 1U);
+  return (byte);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_WriteByte(uint8_t byte) {
+  (void)SPI_Write8(SPI1, &byte, 1U);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_Reset(void) {
+  W5500_RESET_L();
+  Delay_Milliseconds(50U);
+  W5500_RESET_H();
+  Delay_Milliseconds(200U);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w5500_CheckIdentity(void) {
+  uint8_t version = getVERSIONR();
+
+  if (version != 0x04U) {
+    printf("W5500: unexpected version 0x%02x\n", version);
+    return (ERROR);
+  }
+
+  printf("W5500: initialized\n");
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w5500_WaitForLink(void) {
+  uint8_t link = PHY_LINK_OFF;
+
+  for (uint8_t attempt = 0U;
+       (attempt < W5500_LINK_RETRIES) && (link != PHY_LINK_ON);
+       attempt++) {
+    (void)ctlwizchip(CW_GET_PHYLINK, &link);
+    if (link != PHY_LINK_ON) Delay_Milliseconds(500U);
+  }
+
+  printf("W5500 link: %s\n", (link == PHY_LINK_ON) ? "UP" : "DOWN");
+  return ((link == PHY_LINK_ON) ? SUCCESS : ERROR);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_ConfigureNetwork(void) {
+#if W5500_USE_DHCP
+  uint8_t retries = W5500_DHCP_RETRIES;
+
+  w5500AddressAssigned = false;
+  setSHAR(w5500Network.mac);
+  DHCP_init(W5500_DHCP_SOCKET, w5500DhcpBuffer);
+  reg_dhcp_cbfunc(
+    w5500_AddressAssigned,
+    w5500_AddressAssigned,
+    w5500_AddressConflict
+  );
+
+  while (!w5500AddressAssigned && (retries-- > 0U)) {
+    (void)DHCP_run();
+    Delay_Milliseconds(500U);
+  }
+
+  if (w5500AddressAssigned) {
+    getIPfromDHCP(w5500Network.ip);
+    getGWfromDHCP(w5500Network.gw);
+    getSNfromDHCP(w5500Network.sn);
+    getDNSfromDHCP(w5500Network.dns);
+    printf("W5500 network: DHCP\n");
+  } else {
+    w5500Network.dhcp = NETINFO_STATIC;
+    printf("W5500 network: static fallback\n");
+  }
 #else
-    // use static IP (Not DHCP)
-    printf ("Using Static IP..\r\n");
-    ctlnetwork(CN_SET_NETINFO, (void*)&netInfo);
+  printf("W5500 network: static\n");
 #endif
 
-    /***** Configure DNS  *****/
-    // HAL_Delay(500);
-    Delay_Milliseconds(500);
-    printf("Configuring DNS..\r\n");
-    DNS_init(DNS_SOCKET, DNS_buffer);
-
-    /***** Print assigned IP on the console  *****/
-    wiz_NetInfo tmpInfo;
-    ctlnetwork(CN_GET_NETINFO, &tmpInfo);
-    printf("IP: %d.%d.%d.%d\r\n", tmpInfo.ip[0], tmpInfo.ip[1], tmpInfo.ip[2], tmpInfo.ip[3]);
-    printf("SUBNET: %d.%d.%d.%d\r\n", tmpInfo.sn[0], tmpInfo.sn[1], tmpInfo.sn[2], tmpInfo.sn[3]);
-    printf("GATEWAY: %d.%d.%d.%d\r\n", tmpInfo.gw[0], tmpInfo.gw[1], tmpInfo.gw[2], tmpInfo.gw[3]);
-    printf("DNS: %d.%d.%d.%d\r\n", tmpInfo.dns[0], tmpInfo.dns[1], tmpInfo.dns[2], tmpInfo.dns[3]);
-
-
-    SPI_Disable(SPI1);
-
-    return 0;
+  ctlnetwork(CN_SET_NETINFO, &w5500Network);
 }
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_PrintNetwork(void) {
+  wiz_NetInfo network;
+
+  ctlnetwork(CN_GET_NETINFO, &network);
+  printf(
+    "IP: %u.%u.%u.%u\n",
+    network.ip[0], network.ip[1], network.ip[2], network.ip[3]
+  );
+  printf(
+    "SUBNET: %u.%u.%u.%u\n",
+    network.sn[0], network.sn[1], network.sn[2], network.sn[3]
+  );
+  printf(
+    "GATEWAY: %u.%u.%u.%u\n",
+    network.gw[0], network.gw[1], network.gw[2], network.gw[3]
+  );
+  printf(
+    "DNS: %u.%u.%u.%u\n",
+    network.dns[0], network.dns[1], network.dns[2], network.dns[3]
+  );
+}
+
+
+#if W5500_USE_DHCP
+
+// -------------------------------------------------------------
+static void w5500_AddressAssigned(void) {
+  w5500AddressAssigned = true;
+}
+
+
+
+
+// -------------------------------------------------------------
+static void w5500_AddressConflict(void) {
+  w5500AddressAssigned = false;
+}
+
+#endif /* W5500_USE_DHCP */

--- a/Ethernet/wizchip_port.h
+++ b/Ethernet/wizchip_port.h
@@ -1,15 +1,40 @@
-/*
- * wizchip_port.h
- *
- *  Created on: Oct 27, 2025
- *      Author: arunrawat
- */
+/**
+  ******************************************************************************
+  * @file           : wizchip_port.h
+  * @brief          : W5500 board integration and network configuration interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.10.2025
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
 
-#ifndef INC_WIZCHIP_PORT_H_
-#define INC_WIZCHIP_PORT_H_
+#ifndef __WIZCHIP_PORT_H
+#define __WIZCHIP_PORT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+#include <stdint.h>
+
+/**
+  * @brief Initialize the W5500, acquire network configuration, and prepare DNS.
+  * @retval (int) Zero on success; a negative value identifies initialization
+  *         failure and a positive value indicates that the PHY link is down.
+  */
 int W5500_Init(void);
 
+/**
+  * @brief Copy the currently configured IPv4 DNS server address.
+  * @param address (uint8_t*) Destination array containing at least four bytes.
+  */
+void W5500_GetDnsServer(uint8_t* address);
 
-#endif /* INC_WIZCHIP_PORT_H_ */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __WIZCHIP_PORT_H */

--- a/Periph/Inc/buzzer.h
+++ b/Periph/Inc/buzzer.h
@@ -1,0 +1,58 @@
+/**
+  ******************************************************************************
+  * @file           : buzzer.h
+  * @brief          : Passive buzzer PWM interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#ifndef __BUZZER_H
+#define __BUZZER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "misc.h"
+
+#define BUZZER_SELF_TEST_FREQUENCY_HZ  2000U
+#define BUZZER_SELF_TEST_DURATION_MS    200U
+
+/**
+  * @brief Configure PA8 and TIM1 channel 1 for passive-buzzer PWM.
+  * @retval (ErrorStatus) SUCCESS when the output is initialized and silent.
+  */
+ErrorStatus Buzzer_Init(void);
+
+/**
+  * @brief Start a square-wave tone on the buzzer.
+  * @param frequencyHz (uint32_t) Tone frequency in hertz.
+  * @retval (ErrorStatus) SUCCESS when the requested frequency is valid.
+  */
+ErrorStatus Buzzer_Start(uint32_t frequencyHz);
+
+/**
+  * @brief Stop the tone and leave the 2N2222 transistor switched off.
+  */
+void Buzzer_Stop(void);
+
+/**
+  * @brief Emit the short audible startup confirmation tone.
+  * @retval (ErrorStatus) SUCCESS when the test tone was generated.
+  *
+  * This is an operational output test: it verifies the configured timer path,
+  * but it cannot electrically confirm that the buzzer produced sound.
+  */
+ErrorStatus Buzzer_SelfTest(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BUZZER_H */

--- a/Periph/Inc/w25qxx.h
+++ b/Periph/Inc/w25qxx.h
@@ -27,6 +27,12 @@ extern "C" {
 #define W25QXX_BLOCK_32K_SIZE       32768U
 #define W25QXX_BLOCK_64K_SIZE       65536U
 
+#define W25QXX_PACK_ADDRESS(block, sector, page) ( \
+  (((uint32_t)(block) & 0xffffU) << 8U) \
+  | (((uint32_t)(sector) & 0x0fU) << 4U) \
+  | ((uint32_t)(page) & 0x0fU) \
+)
+
 #define W25Q64_JEDEC_ID          0xEF4017UL
 #define W25Q64_CAPACITY_BYTES    0x00800000UL
 
@@ -45,7 +51,7 @@ extern "C" {
   * @param uniqueId (uint8_t[8]) Factory-programmed 64-bit unique identifier.
   * @param capacity (uint32_t) Flash capacity in bytes.
   * @param blockCount (uint16_t) Number of 64 KB blocks.
-  * @param spi (SPI_TypeDef*) SPI peripheral used by the flash.
+  * @param spi (SPI_TypeDef*) SPI peripheral; the current DMA mapping requires SPI2.
   * @param chipSelectPort (GPIO_TypeDef*) GPIO port controlling flash /CS.
   * @param chipSelectPin (uint16_t) GPIO pin number controlling flash /CS.
   */
@@ -62,6 +68,10 @@ typedef struct {
 /**
   * @brief Initialize and identify the W25Q64FV connected to SPI2.
   * @retval (ErrorStatus) SUCCESS when the expected JEDEC ID is detected.
+  *
+  * Initialization configures the software-controlled chip-select pin, reads
+  * the JEDEC and unique identifiers, establishes the device geometry, and
+  * performs the destructive startup self-test in the reserved final sector.
   */
 ErrorStatus W25Qxx_Init(void);
 
@@ -86,6 +96,9 @@ W25Qxx_TypeDef* W25Qxx_GetDevice(void);
   * @param buffer (uint8_t*) Destination buffer owned by the caller.
   * @param length (uint32_t) Number of bytes to read.
   * @retval (ErrorStatus) Status of the operation.
+  *
+  * The packed address identifies the starting 256-byte page. Reads may
+  * continue across page and sector boundaries up to the detected capacity.
   */
 ErrorStatus W25Qxx_Read(uint32_t address, uint8_t* buffer, uint32_t length);
 
@@ -96,7 +109,9 @@ ErrorStatus W25Qxx_Read(uint32_t address, uint8_t* buffer, uint32_t length);
   * @param length (uint32_t) Number of bytes to program.
   * @retval (ErrorStatus) Status of the operation.
   *
-  * The affected sectors must be erased before programming.
+  * The affected sectors must be erased before programming. The driver splits
+  * the transfer at every page boundary because a page-program command cannot
+  * cross a 256-byte page.
   */
 ErrorStatus W25Qxx_Write(
   uint32_t address,
@@ -109,6 +124,9 @@ ErrorStatus W25Qxx_Write(
   * @param address (uint32_t) Packed address; page bits are ignored.
   * @param sectorCount (uint32_t) Number of consecutive 4 KB sectors to erase.
   * @retval (ErrorStatus) Status of the operation.
+  *
+  * The implementation selects aligned 32 KB and 64 KB erase commands where
+  * possible and falls back to individual 4 KB sectors elsewhere.
   */
 ErrorStatus W25Qxx_Erase(uint32_t address, uint32_t sectorCount);
 

--- a/Periph/Inc/w25qxx.h
+++ b/Periph/Inc/w25qxx.h
@@ -1,0 +1,119 @@
+/**
+  ******************************************************************************
+  * @file           : w25qxx.h
+  * @brief          : Winbond W25Qxx SPI NOR flash interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026 09:52:45 AM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#ifndef __W25QXX_H
+#define __W25QXX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "misc.h"
+#include "stm32f103xb.h"
+
+#define W25QXX_PAGE_SIZE              256U
+#define W25QXX_SECTOR_SIZE           4096U
+#define W25QXX_BLOCK_32K_SIZE       32768U
+#define W25QXX_BLOCK_64K_SIZE       65536U
+
+#define W25Q64_JEDEC_ID          0xEF4017UL
+#define W25Q64_CAPACITY_BYTES    0x00800000UL
+
+/*
+ * Packed address of the final 4 KB sector, reserved for the startup self-test.
+ * The address follows the 0x00BBBBSP block/sector/page convention.
+ */
+#define W25Q64_SELF_TEST_ADDRESS       0x00007ff0UL
+
+#define W25Q64_DEFAULT_CS_PORT         GPIOB
+#define W25Q64_DEFAULT_CS_PIN          GPIO_PIN_12
+
+/**
+  * @brief Runtime identity and geometry of a detected W25Qxx flash.
+  * @param jedecId (uint32_t) 24-bit manufacturer, memory-type, and capacity ID.
+  * @param uniqueId (uint8_t[8]) Factory-programmed 64-bit unique identifier.
+  * @param capacity (uint32_t) Flash capacity in bytes.
+  * @param blockCount (uint16_t) Number of 64 KB blocks.
+  * @param spi (SPI_TypeDef*) SPI peripheral used by the flash.
+  * @param chipSelectPort (GPIO_TypeDef*) GPIO port controlling flash /CS.
+  * @param chipSelectPin (uint16_t) GPIO pin number controlling flash /CS.
+  */
+typedef struct {
+  uint32_t jedecId;
+  uint8_t uniqueId[8];
+  uint32_t capacity;
+  uint16_t blockCount;
+  SPI_TypeDef* spi;
+  GPIO_TypeDef* chipSelectPort;
+  uint16_t chipSelectPin;
+} W25Qxx_TypeDef;
+
+/**
+  * @brief Initialize and identify the W25Q64FV connected to SPI2.
+  * @retval (ErrorStatus) SUCCESS when the expected JEDEC ID is detected.
+  */
+ErrorStatus W25Qxx_Init(void);
+
+/**
+  * @brief Verify erase, page-program, and read operations in the test sector.
+  * @retval (ErrorStatus) SUCCESS when the programmed pattern is read correctly.
+  *
+  * This operation erases the final 4 KB flash sector and leaves the test
+  * pattern in its first page. The sector is reserved exclusively for testing.
+  */
+ErrorStatus W25Qxx_SelfTest(void);
+
+/**
+  * @brief Return the statically allocated flash device state.
+  * @retval (W25Qxx_TypeDef*) Detected device state.
+  */
+W25Qxx_TypeDef* W25Qxx_GetDevice(void);
+
+/**
+  * @brief Read bytes from a packed block/sector/page address using SPI2 DMA.
+  * @param address (uint32_t) Packed address in the 0x00BBBBSP format.
+  * @param buffer (uint8_t*) Destination buffer owned by the caller.
+  * @param length (uint32_t) Number of bytes to read.
+  * @retval (ErrorStatus) Status of the operation.
+  */
+ErrorStatus W25Qxx_Read(uint32_t address, uint8_t* buffer, uint32_t length);
+
+/**
+  * @brief Program bytes from a packed block/sector/page address.
+  * @param address (uint32_t) Packed address in the 0x00BBBBSP format.
+  * @param buffer (const uint8_t*) Source buffer owned by the caller.
+  * @param length (uint32_t) Number of bytes to program.
+  * @retval (ErrorStatus) Status of the operation.
+  *
+  * The affected sectors must be erased before programming.
+  */
+ErrorStatus W25Qxx_Write(
+  uint32_t address,
+  const uint8_t* buffer,
+  uint32_t length
+);
+
+/**
+  * @brief Erase sectors beginning at a packed block/sector/page address.
+  * @param address (uint32_t) Packed address; page bits are ignored.
+  * @param sectorCount (uint32_t) Number of consecutive 4 KB sectors to erase.
+  * @retval (ErrorStatus) Status of the operation.
+  */
+ErrorStatus W25Qxx_Erase(uint32_t address, uint32_t sectorCount);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __W25QXX_H */

--- a/Periph/Src/buzzer.c
+++ b/Periph/Src/buzzer.c
@@ -1,0 +1,106 @@
+/**
+  ******************************************************************************
+  * @file           : buzzer.c
+  * @brief          : Passive buzzer PWM implementation using TIM1 channel 1.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#include "buzzer.h"
+#include "common.h"
+#include "stm32f103xb.h"
+
+#define BUZZER_PORT                 GPIOA
+#define BUZZER_PIN                  GPIO_PIN_8
+#define BUZZER_TIMER_CLOCK_HZ       72000000UL
+#define BUZZER_TIMER_TICK_HZ         1000000UL
+#define BUZZER_MIN_FREQUENCY_HZ           16U
+#define BUZZER_MAX_FREQUENCY_HZ        20000U
+
+
+// -------------------------------------------------------------
+ErrorStatus Buzzer_Init(void) {
+  uint32_t shift = (BUZZER_PIN - 8U) * 4U;
+  uint32_t gpioMode = GPIO_AF_PP | GPIO_IOS_2;
+
+  /* Keep the low-side transistor off until PWM is explicitly started. */
+  PIN_L(BUZZER_PORT, BUZZER_PIN);
+  MODIFY_REG(
+    BUZZER_PORT->CRH,
+    0x0fUL << shift,
+    gpioMode << shift
+  );
+
+  CLEAR_BIT(TIM1->CR1, TIM_CR1_CEN);
+  TIM1->PSC = (BUZZER_TIMER_CLOCK_HZ / BUZZER_TIMER_TICK_HZ) - 1U;
+  TIM1->ARR = 0xffffU;
+  TIM1->CCR1 = 0U;
+
+  MODIFY_REG(
+    TIM1->CCMR1,
+    TIM_CCMR1_OC1M | TIM_CCMR1_OC1PE,
+    TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1PE
+  );
+  CLEAR_BIT(TIM1->CCER, TIM_CCER_CC1P);
+  SET_BIT(TIM1->CCER, TIM_CCER_CC1E);
+  SET_BIT(TIM1->BDTR, TIM_BDTR_MOE);
+  SET_BIT(TIM1->CR1, TIM_CR1_ARPE);
+  SET_BIT(TIM1->EGR, TIM_EGR_UG);
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus Buzzer_Start(uint32_t frequencyHz) {
+  uint32_t period;
+
+  if ((frequencyHz < BUZZER_MIN_FREQUENCY_HZ)
+      || (frequencyHz > BUZZER_MAX_FREQUENCY_HZ)) {
+    return (ERROR);
+  }
+
+  period = BUZZER_TIMER_TICK_HZ / frequencyHz;
+  if ((period < 2U) || (period > 0x10000UL)) return (ERROR);
+
+  CLEAR_BIT(TIM1->CR1, TIM_CR1_CEN);
+  TIM1->ARR = period - 1U;
+  TIM1->CCR1 = period / 2U;
+  SET_BIT(TIM1->EGR, TIM_EGR_UG);
+  SET_BIT(TIM1->CR1, TIM_CR1_CEN);
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+void Buzzer_Stop(void) {
+  CLEAR_BIT(TIM1->CR1, TIM_CR1_CEN);
+  TIM1->CCR1 = 0U;
+  SET_BIT(TIM1->EGR, TIM_EGR_UG);
+  PIN_L(BUZZER_PORT, BUZZER_PIN);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus Buzzer_SelfTest(void) {
+  if (Buzzer_Start(BUZZER_SELF_TEST_FREQUENCY_HZ) != SUCCESS) {
+    Buzzer_Stop();
+    return (ERROR);
+  }
+
+  Delay_Milliseconds(BUZZER_SELF_TEST_DURATION_MS);
+  Buzzer_Stop();
+  return (SUCCESS);
+}

--- a/Periph/Src/spi.c
+++ b/Periph/Src/spi.c
@@ -74,8 +74,16 @@ ErrorStatus SPI_Init(SPI_TypeDef* spi) {
 
 ErrorStatus SPI_AdjustConfiguration(SPI_TypeDef* spi) {
 
+  if ((spi != SPI1) && (spi != SPI2)) return (ERROR);
+
   MODIFY_REG(spi->CR1, (SPI_CR1_BR_Msk | SPI_CR1_DFF_Msk), 0);
-  PREG_SET(spi->CR2, SPI_CR2_SSOE_Pos);
+
+  if (spi == SPI2) {
+    SET_BIT(spi->CR1, SPI_CR1_SSM | SPI_CR1_SSI);
+    PREG_CLR(spi->CR2, SPI_CR2_SSOE_Pos);
+  } else {
+    PREG_SET(spi->CR2, SPI_CR2_SSOE_Pos);
+  }
 
   return (SUCCESS);
 }

--- a/Periph/Src/w25qxx.c
+++ b/Periph/Src/w25qxx.c
@@ -1,0 +1,555 @@
+/**
+  ******************************************************************************
+  * @file           : w25qxx.c
+  * @brief          : Winbond W25Qxx SPI NOR flash implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026 09:52:45 AM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#include "w25qxx.h"
+#include "common.h"
+#include "spi.h"
+#include <stddef.h>
+
+#define W25QXX_COMMAND_WRITE_ENABLE          0x06U
+#define W25QXX_COMMAND_READ_JEDEC_ID         0x9fU
+#define W25QXX_COMMAND_READ_UNIQUE_ID        0x4bU
+#define W25QXX_COMMAND_READ_STATUS_1         0x05U
+#define W25QXX_COMMAND_PAGE_PROGRAM          0x02U
+#define W25QXX_COMMAND_FAST_READ             0x0bU
+#define W25QXX_COMMAND_ERASE_SECTOR          0x20U
+#define W25QXX_COMMAND_ERASE_BLOCK_32K       0x52U
+#define W25QXX_COMMAND_ERASE_BLOCK_64K       0xd8U
+
+#define W25QXX_STATUS_BUSY                   0x01U
+#define W25QXX_DMA_TRANSFER_LIMIT           0xffffU
+#define W25QXX_OPERATION_TIMEOUT          1000000U
+#define W25QXX_SELF_TEST_SEED                 0xa5U
+#define W25QXX_SELF_TEST_STEP                 0x25U
+
+#define W25QXX_SELECT() \
+  PIN_L(w25qxxDevice.chipSelectPort, w25qxxDevice.chipSelectPin)
+#define W25QXX_RELEASE() \
+  PIN_H(w25qxxDevice.chipSelectPort, w25qxxDevice.chipSelectPin)
+
+static W25Qxx_TypeDef w25qxxDevice = {
+  .jedecId = 0U,
+  .uniqueId = {0U},
+  .capacity = 0U,
+  .blockCount = 0U,
+  .spi = SPI2,
+  .chipSelectPort = W25Q64_DEFAULT_CS_PORT,
+  .chipSelectPin = W25Q64_DEFAULT_CS_PIN,
+};
+
+static ErrorStatus w25qxx_ChipSelectInit(void);
+static uint32_t w25qxx_DecodeAddress(uint32_t address);
+static ErrorStatus w25qxx_ValidateRange(uint32_t address, uint32_t length);
+static ErrorStatus w25qxx_TransferDMA(
+  const uint8_t* transmitBuffer,
+  uint8_t* receiveBuffer,
+  uint16_t length
+);
+static ErrorStatus w25qxx_SendHeader(
+  uint8_t command,
+  uint32_t address,
+  uint8_t addressLength,
+  uint8_t dummyLength
+);
+static ErrorStatus w25qxx_ReadCommand(
+  uint8_t command,
+  uint32_t address,
+  uint8_t addressLength,
+  uint8_t dummyLength,
+  uint8_t* buffer,
+  uint32_t length
+);
+static ErrorStatus w25qxx_Command(uint8_t command, uint32_t address);
+static ErrorStatus w25qxx_WaitWhileBusy(void);
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus W25Qxx_Init(void) {
+  uint8_t jedecId[3];
+
+  if (w25qxx_ChipSelectInit() != SUCCESS) return (ERROR);
+
+  if (w25qxx_ReadCommand(
+      W25QXX_COMMAND_READ_JEDEC_ID,
+      0U,
+      0U,
+      0U,
+      jedecId,
+      sizeof(jedecId)
+    ) != SUCCESS) {
+    return (ERROR);
+  }
+
+  w25qxxDevice.jedecId = ((uint32_t)jedecId[0] << 16U)
+    | ((uint32_t)jedecId[1] << 8U)
+    | jedecId[2];
+
+  if (w25qxxDevice.jedecId != W25Q64_JEDEC_ID) return (ERROR);
+
+  if (w25qxx_ReadCommand(
+      W25QXX_COMMAND_READ_UNIQUE_ID,
+      0U,
+      0U,
+      4U,
+      w25qxxDevice.uniqueId,
+      sizeof(w25qxxDevice.uniqueId)
+    ) != SUCCESS) {
+    return (ERROR);
+  }
+
+  w25qxxDevice.capacity = W25Q64_CAPACITY_BYTES;
+  w25qxxDevice.blockCount =
+    (uint16_t)(W25Q64_CAPACITY_BYTES / W25QXX_BLOCK_64K_SIZE);
+
+  return (W25Qxx_SelfTest());
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus W25Qxx_SelfTest(void) {
+  uint8_t buffer[W25QXX_PAGE_SIZE];
+
+  if (W25Qxx_Erase(W25Q64_SELF_TEST_ADDRESS, 1U) != SUCCESS) {
+    return (ERROR);
+  }
+
+  for (uint32_t index = 0U; index < sizeof(buffer); index++) {
+    buffer[index] = (uint8_t)(
+      W25QXX_SELF_TEST_SEED ^ (index * W25QXX_SELF_TEST_STEP)
+    );
+  }
+
+  if (W25Qxx_Write(
+      W25Q64_SELF_TEST_ADDRESS,
+      buffer,
+      sizeof(buffer)
+    ) != SUCCESS) {
+    return (ERROR);
+  }
+
+  for (uint32_t index = 0U; index < sizeof(buffer); index++) {
+    buffer[index] = 0U;
+  }
+
+  if (W25Qxx_Read(
+      W25Q64_SELF_TEST_ADDRESS,
+      buffer,
+      sizeof(buffer)
+    ) != SUCCESS) {
+    return (ERROR);
+  }
+
+  for (uint32_t index = 0U; index < sizeof(buffer); index++) {
+    uint8_t expected = (uint8_t)(
+      W25QXX_SELF_TEST_SEED ^ (index * W25QXX_SELF_TEST_STEP)
+    );
+    if (buffer[index] != expected) return (ERROR);
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+W25Qxx_TypeDef* W25Qxx_GetDevice(void) {
+  return (&w25qxxDevice);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus W25Qxx_Read(
+  uint32_t address,
+  uint8_t* buffer,
+  uint32_t length
+) {
+  uint32_t physicalAddress;
+
+  if ((buffer == NULL) || (length == 0U)) return (ERROR);
+
+  physicalAddress = w25qxx_DecodeAddress(address);
+  if (w25qxx_ValidateRange(physicalAddress, length) != SUCCESS) return (ERROR);
+
+  return (w25qxx_ReadCommand(
+    W25QXX_COMMAND_FAST_READ,
+    physicalAddress,
+    3U,
+    1U,
+    buffer,
+    length
+  ));
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus W25Qxx_Write(
+  uint32_t address,
+  const uint8_t* buffer,
+  uint32_t length
+) {
+  uint32_t physicalAddress;
+
+  if ((buffer == NULL) || (length == 0U)) return (ERROR);
+
+  physicalAddress = w25qxx_DecodeAddress(address);
+  if (w25qxx_ValidateRange(physicalAddress, length) != SUCCESS) return (ERROR);
+
+  while (length > 0U) {
+    uint32_t pageRemaining =
+      W25QXX_PAGE_SIZE - (physicalAddress % W25QXX_PAGE_SIZE);
+    uint16_t chunk = (uint16_t)(
+      (length < pageRemaining) ? length : pageRemaining
+    );
+    ErrorStatus status;
+
+    if (w25qxx_Command(W25QXX_COMMAND_WRITE_ENABLE, 0U) != SUCCESS) {
+      return (ERROR);
+    }
+
+    if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+    W25QXX_SELECT();
+
+    status = w25qxx_SendHeader(
+      W25QXX_COMMAND_PAGE_PROGRAM,
+      physicalAddress,
+      3U,
+      0U
+    );
+    if (status == SUCCESS) {
+      status = w25qxx_TransferDMA(buffer, NULL, chunk);
+    }
+
+    W25QXX_RELEASE();
+    if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) status = ERROR;
+    if (status != SUCCESS) return (ERROR);
+    if (w25qxx_WaitWhileBusy() != SUCCESS) return (ERROR);
+
+    physicalAddress += chunk;
+    buffer += chunk;
+    length -= chunk;
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+ErrorStatus W25Qxx_Erase(uint32_t address, uint32_t sectorCount) {
+  uint32_t physicalAddress = w25qxx_DecodeAddress(address);
+  uint32_t eraseLength;
+
+  physicalAddress -= physicalAddress % W25QXX_SECTOR_SIZE;
+  if ((sectorCount == 0U)
+      || (sectorCount > (UINT32_MAX / W25QXX_SECTOR_SIZE))) {
+    return (ERROR);
+  }
+
+  eraseLength = sectorCount * W25QXX_SECTOR_SIZE;
+  if (w25qxx_ValidateRange(physicalAddress, eraseLength) != SUCCESS) {
+    return (ERROR);
+  }
+
+  while (sectorCount > 0U) {
+    uint8_t command = W25QXX_COMMAND_ERASE_SECTOR;
+    uint32_t erasedSectors = 1U;
+
+    if (((physicalAddress % W25QXX_BLOCK_64K_SIZE) == 0U)
+        && (sectorCount >= 16U)) {
+      command = W25QXX_COMMAND_ERASE_BLOCK_64K;
+      erasedSectors = 16U;
+    } else if (((physicalAddress % W25QXX_BLOCK_32K_SIZE) == 0U)
+        && (sectorCount >= 8U)) {
+      command = W25QXX_COMMAND_ERASE_BLOCK_32K;
+      erasedSectors = 8U;
+    }
+
+    if (w25qxx_Command(W25QXX_COMMAND_WRITE_ENABLE, 0U) != SUCCESS) {
+      return (ERROR);
+    }
+    if (w25qxx_Command(command, physicalAddress) != SUCCESS) return (ERROR);
+    if (w25qxx_WaitWhileBusy() != SUCCESS) return (ERROR);
+
+    physicalAddress += erasedSectors * W25QXX_SECTOR_SIZE;
+    sectorCount -= erasedSectors;
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_ChipSelectInit(void) {
+  uint32_t shift;
+  uint32_t mode = GPIO_GPO_PP | GPIO_IOS_50;
+
+  if ((w25qxxDevice.chipSelectPort == NULL)
+      || (w25qxxDevice.chipSelectPin > GPIO_PIN_15)) {
+    return (ERROR);
+  }
+
+  W25QXX_RELEASE();
+
+  if (w25qxxDevice.chipSelectPin < GPIO_PIN_8) {
+    shift = w25qxxDevice.chipSelectPin * 4U;
+    MODIFY_REG(
+      w25qxxDevice.chipSelectPort->CRL,
+      (0xfU << shift),
+      (mode << shift)
+    );
+  } else {
+    shift = (w25qxxDevice.chipSelectPin - GPIO_PIN_8) * 4U;
+    MODIFY_REG(
+      w25qxxDevice.chipSelectPort->CRH,
+      (0xfU << shift),
+      (mode << shift)
+    );
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static uint32_t w25qxx_DecodeAddress(uint32_t address) {
+  uint32_t block = (address >> 8U) & 0xffffU;
+  uint32_t sector = (address >> 4U) & 0x0fU;
+  uint32_t page = address & 0x0fU;
+
+  return (block * W25QXX_BLOCK_64K_SIZE)
+    + (sector * W25QXX_SECTOR_SIZE)
+    + (page * W25QXX_PAGE_SIZE);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_ValidateRange(
+  uint32_t address,
+  uint32_t length
+) {
+  if ((w25qxxDevice.capacity == 0U)
+      || (address >= w25qxxDevice.capacity)
+      || (length > (w25qxxDevice.capacity - address))) {
+    return (ERROR);
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_TransferDMA(
+  const uint8_t* transmitBuffer,
+  uint8_t* receiveBuffer,
+  uint16_t length
+) {
+  uint8_t dummyTransmit = 0U;
+  uint8_t discardReceive;
+  uint32_t timeout = W25QXX_OPERATION_TIMEOUT;
+  ErrorStatus status = SUCCESS;
+
+  if (length == 0U) return (SUCCESS);
+
+  CLEAR_BIT(DMA1_Channel4->CCR, DMA_CCR_EN);
+  CLEAR_BIT(DMA1_Channel5->CCR, DMA_CCR_EN);
+  DMA1->IFCR = DMA_IFCR_CGIF4 | DMA_IFCR_CGIF5;
+
+  DMA1_Channel4->CPAR = (uint32_t)&w25qxxDevice.spi->DR;
+  DMA1_Channel4->CMAR = (uint32_t)(
+    (receiveBuffer != NULL) ? receiveBuffer : &discardReceive
+  );
+  DMA1_Channel4->CNDTR = length;
+  DMA1_Channel4->CCR = DMA_CCR_PL_1
+    | ((receiveBuffer != NULL) ? DMA_CCR_MINC : 0U);
+
+  DMA1_Channel5->CPAR = (uint32_t)&w25qxxDevice.spi->DR;
+  DMA1_Channel5->CMAR = (uint32_t)(
+    (transmitBuffer != NULL) ? transmitBuffer : &dummyTransmit
+  );
+  DMA1_Channel5->CNDTR = length;
+  DMA1_Channel5->CCR = DMA_CCR_DIR
+    | DMA_CCR_PL_1
+    | ((transmitBuffer != NULL) ? DMA_CCR_MINC : 0U);
+
+  SET_BIT(
+    w25qxxDevice.spi->CR2,
+    SPI_CR2_RXDMAEN | SPI_CR2_TXDMAEN
+  );
+  SET_BIT(DMA1_Channel4->CCR, DMA_CCR_EN);
+  SET_BIT(DMA1_Channel5->CCR, DMA_CCR_EN);
+
+  while (((DMA1->ISR & DMA_ISR_TCIF4) == 0U)
+      || ((DMA1->ISR & DMA_ISR_TCIF5) == 0U)) {
+    if ((DMA1->ISR & (DMA_ISR_TEIF4 | DMA_ISR_TEIF5)) != 0U) {
+      status = ERROR;
+      break;
+    }
+    if (--timeout == 0U) {
+      status = ERROR;
+      break;
+    }
+  }
+
+  while ((status == SUCCESS)
+      && PREG_CHECK(w25qxxDevice.spi->SR, SPI_SR_BSY_Pos)) {
+    if (--timeout == 0U) status = ERROR;
+  }
+
+  CLEAR_BIT(DMA1_Channel4->CCR, DMA_CCR_EN);
+  CLEAR_BIT(DMA1_Channel5->CCR, DMA_CCR_EN);
+  CLEAR_BIT(
+    w25qxxDevice.spi->CR2,
+    SPI_CR2_RXDMAEN | SPI_CR2_TXDMAEN
+  );
+  DMA1->IFCR = DMA_IFCR_CGIF4 | DMA_IFCR_CGIF5;
+
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_SendHeader(
+  uint8_t command,
+  uint32_t address,
+  uint8_t addressLength,
+  uint8_t dummyLength
+) {
+  uint8_t addressBytes[3];
+  uint8_t dummy = 0U;
+
+  if (SPI_Write8(w25qxxDevice.spi, &command, 1U) != SUCCESS) return (ERROR);
+
+  if (addressLength > 0U) {
+    addressBytes[0] = (uint8_t)(address >> 16U);
+    addressBytes[1] = (uint8_t)(address >> 8U);
+    addressBytes[2] = (uint8_t)address;
+    if (SPI_Write8(
+        w25qxxDevice.spi,
+        addressBytes,
+        addressLength
+      ) != SUCCESS) {
+      return (ERROR);
+    }
+  }
+
+  while (dummyLength-- > 0U) {
+    if (SPI_Write8(w25qxxDevice.spi, &dummy, 1U) != SUCCESS) return (ERROR);
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_ReadCommand(
+  uint8_t command,
+  uint32_t address,
+  uint8_t addressLength,
+  uint8_t dummyLength,
+  uint8_t* buffer,
+  uint32_t length
+) {
+  ErrorStatus status;
+
+  if ((buffer == NULL) || (length == 0U)) return (ERROR);
+  if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+
+  W25QXX_SELECT();
+  status = w25qxx_SendHeader(
+    command,
+    address,
+    addressLength,
+    dummyLength
+  );
+
+  while ((status == SUCCESS) && (length > 0U)) {
+    uint16_t chunk = (uint16_t)(
+      (length > W25QXX_DMA_TRANSFER_LIMIT)
+        ? W25QXX_DMA_TRANSFER_LIMIT
+        : length
+    );
+    status = w25qxx_TransferDMA(NULL, buffer, chunk);
+    buffer += chunk;
+    length -= chunk;
+  }
+
+  W25QXX_RELEASE();
+  if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) status = ERROR;
+
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_Command(uint8_t command, uint32_t address) {
+  ErrorStatus status;
+  uint8_t addressLength = (command == W25QXX_COMMAND_WRITE_ENABLE) ? 0U : 3U;
+
+  if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+
+  W25QXX_SELECT();
+  status = w25qxx_SendHeader(command, address, addressLength, 0U);
+  W25QXX_RELEASE();
+
+  if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) status = ERROR;
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus w25qxx_WaitWhileBusy(void) {
+  uint8_t statusRegister = W25QXX_STATUS_BUSY;
+  uint32_t timeout = W25QXX_OPERATION_TIMEOUT;
+
+  while ((statusRegister & W25QXX_STATUS_BUSY) != 0U) {
+    if (w25qxx_ReadCommand(
+        W25QXX_COMMAND_READ_STATUS_1,
+        0U,
+        0U,
+        0U,
+        &statusRegister,
+        1U
+      ) != SUCCESS) {
+      return (ERROR);
+    }
+    if (--timeout == 0U) return (ERROR);
+  }
+
+  return (SUCCESS);
+}

--- a/Periph/Src/w25qxx.c
+++ b/Periph/Src/w25qxx.c
@@ -27,8 +27,12 @@
 #define W25QXX_COMMAND_ERASE_BLOCK_64K       0xd8U
 
 #define W25QXX_STATUS_BUSY                   0x01U
+#define W25QXX_ADDRESS_LENGTH                3U
+#define W25QXX_FAST_READ_DUMMY_LENGTH        1U
+#define W25QXX_UNIQUE_ID_DUMMY_LENGTH        4U
 #define W25QXX_DMA_TRANSFER_LIMIT           0xffffU
-#define W25QXX_OPERATION_TIMEOUT          1000000U
+#define W25QXX_DMA_TIMEOUT                1000000U
+#define W25QXX_BUSY_POLL_LIMIT            1000000U
 #define W25QXX_SELF_TEST_SEED                 0xa5U
 #define W25QXX_SELF_TEST_STEP                 0x25U
 
@@ -48,6 +52,8 @@ static W25Qxx_TypeDef w25qxxDevice = {
 };
 
 static ErrorStatus w25qxx_ChipSelectInit(void);
+static ErrorStatus w25qxx_BeginTransaction(void);
+static ErrorStatus w25qxx_EndTransaction(ErrorStatus status);
 static uint32_t w25qxx_DecodeAddress(uint32_t address);
 static ErrorStatus w25qxx_ValidateRange(uint32_t address, uint32_t length);
 static ErrorStatus w25qxx_TransferDMA(
@@ -69,7 +75,18 @@ static ErrorStatus w25qxx_ReadCommand(
   uint8_t* buffer,
   uint32_t length
 );
-static ErrorStatus w25qxx_Command(uint8_t command, uint32_t address);
+static ErrorStatus w25qxx_Command(
+  uint8_t command,
+  uint32_t address,
+  uint8_t addressLength
+);
+static ErrorStatus w25qxx_WriteEnable(void);
+static ErrorStatus w25qxx_ProgramPage(
+  uint32_t address,
+  const uint8_t* buffer,
+  uint16_t length
+);
+static ErrorStatus w25qxx_EraseUnit(uint8_t command, uint32_t address);
 static ErrorStatus w25qxx_WaitWhileBusy(void);
 
 
@@ -79,6 +96,14 @@ static ErrorStatus w25qxx_WaitWhileBusy(void);
 ErrorStatus W25Qxx_Init(void) {
   uint8_t jedecId[3];
 
+  w25qxxDevice.jedecId = 0U;
+  w25qxxDevice.capacity = 0U;
+  w25qxxDevice.blockCount = 0U;
+  for (uint32_t index = 0U; index < sizeof(w25qxxDevice.uniqueId); index++) {
+    w25qxxDevice.uniqueId[index] = 0U;
+  }
+
+  if (w25qxxDevice.spi != SPI2) return (ERROR);
   if (w25qxx_ChipSelectInit() != SUCCESS) return (ERROR);
 
   if (w25qxx_ReadCommand(
@@ -102,7 +127,7 @@ ErrorStatus W25Qxx_Init(void) {
       W25QXX_COMMAND_READ_UNIQUE_ID,
       0U,
       0U,
-      4U,
+      W25QXX_UNIQUE_ID_DUMMY_LENGTH,
       w25qxxDevice.uniqueId,
       sizeof(w25qxxDevice.uniqueId)
     ) != SUCCESS) {
@@ -190,8 +215,8 @@ ErrorStatus W25Qxx_Read(
   return (w25qxx_ReadCommand(
     W25QXX_COMMAND_FAST_READ,
     physicalAddress,
-    3U,
-    1U,
+    W25QXX_ADDRESS_LENGTH,
+    W25QXX_FAST_READ_DUMMY_LENGTH,
     buffer,
     length
   ));
@@ -219,28 +244,10 @@ ErrorStatus W25Qxx_Write(
     uint16_t chunk = (uint16_t)(
       (length < pageRemaining) ? length : pageRemaining
     );
-    ErrorStatus status;
 
-    if (w25qxx_Command(W25QXX_COMMAND_WRITE_ENABLE, 0U) != SUCCESS) {
+    if (w25qxx_ProgramPage(physicalAddress, buffer, chunk) != SUCCESS) {
       return (ERROR);
     }
-
-    if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
-    W25QXX_SELECT();
-
-    status = w25qxx_SendHeader(
-      W25QXX_COMMAND_PAGE_PROGRAM,
-      physicalAddress,
-      3U,
-      0U
-    );
-    if (status == SUCCESS) {
-      status = w25qxx_TransferDMA(buffer, NULL, chunk);
-    }
-
-    W25QXX_RELEASE();
-    if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) status = ERROR;
-    if (status != SUCCESS) return (ERROR);
     if (w25qxx_WaitWhileBusy() != SUCCESS) return (ERROR);
 
     physicalAddress += chunk;
@@ -284,11 +291,7 @@ ErrorStatus W25Qxx_Erase(uint32_t address, uint32_t sectorCount) {
       erasedSectors = 8U;
     }
 
-    if (w25qxx_Command(W25QXX_COMMAND_WRITE_ENABLE, 0U) != SUCCESS) {
-      return (ERROR);
-    }
-    if (w25qxx_Command(command, physicalAddress) != SUCCESS) return (ERROR);
-    if (w25qxx_WaitWhileBusy() != SUCCESS) return (ERROR);
+    if (w25qxx_EraseUnit(command, physicalAddress) != SUCCESS) return (ERROR);
 
     physicalAddress += erasedSectors * W25QXX_SECTOR_SIZE;
     sectorCount -= erasedSectors;
@@ -301,6 +304,13 @@ ErrorStatus W25Qxx_Erase(uint32_t address, uint32_t sectorCount) {
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Configure the device-specific software chip-select GPIO.
+  * @retval (ErrorStatus) SUCCESS when the configured port and pin are valid.
+  *
+  * The output latch is driven high before the pin becomes push-pull output so
+  * that initialization cannot briefly select the flash.
+  */
 static ErrorStatus w25qxx_ChipSelectInit(void) {
   uint32_t shift;
   uint32_t mode = GPIO_GPO_PP | GPIO_IOS_50;
@@ -335,6 +345,43 @@ static ErrorStatus w25qxx_ChipSelectInit(void) {
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Enable SPI and select the flash for one complete command transaction.
+  * @retval (ErrorStatus) SUCCESS when the SPI peripheral was enabled.
+  */
+static ErrorStatus w25qxx_BeginTransaction(void) {
+  if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+  W25QXX_SELECT();
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+/**
+  * @brief Release the flash and disable SPI after a command transaction.
+  * @param status (ErrorStatus) Status accumulated during the transaction.
+  * @retval (ErrorStatus) ERROR when the transaction or SPI shutdown failed.
+  */
+static ErrorStatus w25qxx_EndTransaction(ErrorStatus status) {
+  W25QXX_RELEASE();
+  if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+  return (status);
+}
+
+
+
+
+// -------------------------------------------------------------
+/**
+  * @brief Convert the legacy packed address into a physical byte address.
+  * @param address (uint32_t) Address encoded as 0x00BBBBSP.
+  * @retval (uint32_t) Physical byte offset within the flash.
+  *
+  * BBBB selects a 64 KB block, S selects one of its sixteen 4 KB sectors, and
+  * P selects one of the sector's sixteen 256-byte pages.
+  */
 static uint32_t w25qxx_DecodeAddress(uint32_t address) {
   uint32_t block = (address >> 8U) & 0xffffU;
   uint32_t sector = (address >> 4U) & 0x0fU;
@@ -349,6 +396,12 @@ static uint32_t w25qxx_DecodeAddress(uint32_t address) {
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Check that a physical byte range lies inside the detected flash.
+  * @param address (uint32_t) Physical starting byte address.
+  * @param length (uint32_t) Number of bytes in the requested range.
+  * @retval (ErrorStatus) SUCCESS for a non-overflowing in-range request.
+  */
 static ErrorStatus w25qxx_ValidateRange(
   uint32_t address,
   uint32_t length
@@ -366,6 +419,16 @@ static ErrorStatus w25qxx_ValidateRange(
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Transfer one full-duplex SPI2 payload using DMA1 channels 4 and 5.
+  * @param transmitBuffer (const uint8_t*) Source data, or NULL to send zeros.
+  * @param receiveBuffer (uint8_t*) Destination, or NULL to discard received data.
+  * @param length (uint16_t) Number of bytes to exchange.
+  * @retval (ErrorStatus) Status of DMA completion and final SPI idle wait.
+  *
+  * Memory increment is disabled for the single dummy and discard bytes. This
+  * avoids the out-of-bounds DMA access present in the original implementation.
+  */
 static ErrorStatus w25qxx_TransferDMA(
   const uint8_t* transmitBuffer,
   uint8_t* receiveBuffer,
@@ -373,7 +436,7 @@ static ErrorStatus w25qxx_TransferDMA(
 ) {
   uint8_t dummyTransmit = 0U;
   uint8_t discardReceive;
-  uint32_t timeout = W25QXX_OPERATION_TIMEOUT;
+  uint32_t timeout = W25QXX_DMA_TIMEOUT;
   ErrorStatus status = SUCCESS;
 
   if (length == 0U) return (SUCCESS);
@@ -438,6 +501,16 @@ static ErrorStatus w25qxx_TransferDMA(
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Send a command byte followed by optional address and dummy bytes.
+  * @param command (uint8_t) Winbond command opcode.
+  * @param address (uint32_t) Physical 24-bit flash address.
+  * @param addressLength (uint8_t) Number of address bytes to send.
+  * @param dummyLength (uint8_t) Number of zero-valued dummy bytes to send.
+  * @retval (ErrorStatus) Status of the polling SPI transfers.
+  *
+  * The caller must already own an active transaction with chip select low.
+  */
 static ErrorStatus w25qxx_SendHeader(
   uint8_t command,
   uint32_t address,
@@ -447,6 +520,7 @@ static ErrorStatus w25qxx_SendHeader(
   uint8_t addressBytes[3];
   uint8_t dummy = 0U;
 
+  if (addressLength > sizeof(addressBytes)) return (ERROR);
   if (SPI_Write8(w25qxxDevice.spi, &command, 1U) != SUCCESS) return (ERROR);
 
   if (addressLength > 0U) {
@@ -473,6 +547,16 @@ static ErrorStatus w25qxx_SendHeader(
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Execute a command that returns a payload through DMA.
+  * @param command (uint8_t) Winbond read command opcode.
+  * @param address (uint32_t) Physical address when required by the command.
+  * @param addressLength (uint8_t) Number of address bytes to send.
+  * @param dummyLength (uint8_t) Number of command-specific dummy bytes.
+  * @param buffer (uint8_t*) Destination buffer.
+  * @param length (uint32_t) Number of payload bytes to receive.
+  * @retval (ErrorStatus) Status of the complete transaction.
+  */
 static ErrorStatus w25qxx_ReadCommand(
   uint8_t command,
   uint32_t address,
@@ -484,9 +568,8 @@ static ErrorStatus w25qxx_ReadCommand(
   ErrorStatus status;
 
   if ((buffer == NULL) || (length == 0U)) return (ERROR);
-  if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+  if (w25qxx_BeginTransaction() != SUCCESS) return (ERROR);
 
-  W25QXX_SELECT();
   status = w25qxx_SendHeader(
     command,
     address,
@@ -505,37 +588,130 @@ static ErrorStatus w25qxx_ReadCommand(
     length -= chunk;
   }
 
-  W25QXX_RELEASE();
-  if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) status = ERROR;
-
-  return (status);
+  return (w25qxx_EndTransaction(status));
 }
 
 
 
 
 // -------------------------------------------------------------
-static ErrorStatus w25qxx_Command(uint8_t command, uint32_t address) {
+/**
+  * @brief Execute a command that has no returned payload.
+  * @param command (uint8_t) Winbond command opcode.
+  * @param address (uint32_t) Physical address when required.
+  * @param addressLength (uint8_t) Number of address bytes to send.
+  * @retval (ErrorStatus) Status of the complete transaction.
+  */
+static ErrorStatus w25qxx_Command(
+  uint8_t command,
+  uint32_t address,
+  uint8_t addressLength
+) {
   ErrorStatus status;
-  uint8_t addressLength = (command == W25QXX_COMMAND_WRITE_ENABLE) ? 0U : 3U;
 
-  if (SPI_Enable(w25qxxDevice.spi) != SUCCESS) return (ERROR);
+  if (w25qxx_BeginTransaction() != SUCCESS) return (ERROR);
 
-  W25QXX_SELECT();
   status = w25qxx_SendHeader(command, address, addressLength, 0U);
-  W25QXX_RELEASE();
-
-  if (SPI_Disable(w25qxxDevice.spi) != SUCCESS) status = ERROR;
-  return (status);
+  return (w25qxx_EndTransaction(status));
 }
 
 
 
 
 // -------------------------------------------------------------
+/**
+  * @brief Set the flash write-enable latch before program or erase.
+  * @retval (ErrorStatus) Status of the write-enable command transaction.
+  */
+static ErrorStatus w25qxx_WriteEnable(void) {
+  return (w25qxx_Command(
+    W25QXX_COMMAND_WRITE_ENABLE,
+    0U,
+    0U
+  ));
+}
+
+
+
+
+// -------------------------------------------------------------
+/**
+  * @brief Program data without crossing the current 256-byte page boundary.
+  * @param address (uint32_t) Physical starting byte address.
+  * @param buffer (const uint8_t*) Source bytes.
+  * @param length (uint16_t) Bytes to program within the current page.
+  * @retval (ErrorStatus) Status of write-enable, header, and DMA transfer.
+  */
+static ErrorStatus w25qxx_ProgramPage(
+  uint32_t address,
+  const uint8_t* buffer,
+  uint16_t length
+) {
+  ErrorStatus status;
+
+  if ((buffer == NULL)
+      || (length == 0U)
+      || (length > W25QXX_PAGE_SIZE)
+      || ((address % W25QXX_PAGE_SIZE) + length > W25QXX_PAGE_SIZE)) {
+    return (ERROR);
+  }
+
+  if (w25qxx_WriteEnable() != SUCCESS) return (ERROR);
+  if (w25qxx_BeginTransaction() != SUCCESS) return (ERROR);
+
+  status = w25qxx_SendHeader(
+    W25QXX_COMMAND_PAGE_PROGRAM,
+    address,
+    W25QXX_ADDRESS_LENGTH,
+    0U
+  );
+  if (status == SUCCESS) {
+    status = w25qxx_TransferDMA(buffer, NULL, length);
+  }
+
+  return (w25qxx_EndTransaction(status));
+}
+
+
+
+
+// -------------------------------------------------------------
+/**
+  * @brief Erase one aligned sector or block and wait for completion.
+  * @param command (uint8_t) Sector, 32 KB block, or 64 KB block opcode.
+  * @param address (uint32_t) Physical address aligned for the selected opcode.
+  * @retval (ErrorStatus) Status of write-enable, erase, and busy polling.
+  */
+static ErrorStatus w25qxx_EraseUnit(uint8_t command, uint32_t address) {
+  if ((command != W25QXX_COMMAND_ERASE_SECTOR)
+      && (command != W25QXX_COMMAND_ERASE_BLOCK_32K)
+      && (command != W25QXX_COMMAND_ERASE_BLOCK_64K)) {
+    return (ERROR);
+  }
+
+  if (w25qxx_WriteEnable() != SUCCESS) return (ERROR);
+  if (w25qxx_Command(
+      command,
+      address,
+      W25QXX_ADDRESS_LENGTH
+    ) != SUCCESS) {
+    return (ERROR);
+  }
+
+  return (w25qxx_WaitWhileBusy());
+}
+
+
+
+
+// -------------------------------------------------------------
+/**
+  * @brief Poll status register 1 until program or erase completes.
+  * @retval (ErrorStatus) SUCCESS when BUSY clears before the polling limit.
+  */
 static ErrorStatus w25qxx_WaitWhileBusy(void) {
   uint8_t statusRegister = W25QXX_STATUS_BUSY;
-  uint32_t timeout = W25QXX_OPERATION_TIMEOUT;
+  uint32_t remainingPolls = W25QXX_BUSY_POLL_LIMIT;
 
   while ((statusRegister & W25QXX_STATUS_BUSY) != 0U) {
     if (w25qxx_ReadCommand(
@@ -548,7 +724,7 @@ static ErrorStatus w25qxx_WaitWhileBusy(void) {
       ) != SUCCESS) {
       return (ERROR);
     }
-    if (--timeout == 0U) return (ERROR);
+    if (--remainingPolls == 0U) return (ERROR);
   }
 
   return (SUCCESS);

--- a/Srv/Inc/device_health.h
+++ b/Srv/Inc/device_health.h
@@ -1,0 +1,48 @@
+/**
+  ******************************************************************************
+  * @file           : device_health.h
+  * @brief          : Shared physical-device availability state.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026 03:11:07 PM
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#ifndef __DEVICE_HEALTH_H
+#define __DEVICE_HEALTH_H
+
+#include <stdint.h>
+#include "FreeRTOS.h"
+
+/**
+  * @brief Availability states shared by physical devices.
+  */
+typedef enum {
+  DEVICE_HEALTH_INITIALIZING = 0U,
+  DEVICE_HEALTH_AVAILABLE,
+  DEVICE_HEALTH_DEGRADED,
+  DEVICE_HEALTH_UNAVAILABLE,
+  DEVICE_HEALTH_STALE,
+  DEVICE_HEALTH_MISSING
+} DeviceHealthState_TypeDef;
+
+/**
+  * @brief Latest availability history maintained by a device-owning service.
+  * @param lastAttempt (TickType_t) Tick of the latest availability attempt.
+  * @param lastSuccess (TickType_t) Tick of the latest successful operation.
+  * @param consecutiveFailures (uint16_t) Failures since the last success.
+  * @param lastError (uint8_t) Device-specific error code from the last attempt.
+  * @param state (DeviceHealthState_TypeDef) Derived device availability state.
+  */
+typedef struct {
+  TickType_t lastAttempt;
+  TickType_t lastSuccess;
+  uint16_t consecutiveFailures;
+  DeviceHealthState_TypeDef state;
+  uint8_t lastError;
+} DeviceHealth_TypeDef;
+
+#endif /* __DEVICE_HEALTH_H */

--- a/Srv/Inc/health_service.h
+++ b/Srv/Inc/health_service.h
@@ -15,6 +15,7 @@
 #define __HEALTH_SERVICE_H
 
 #include "main.h"
+#include "device_health.h"
 
 /**
   * @brief Bit mask identifying services supervised by the health service.

--- a/Srv/Inc/health_service.h
+++ b/Srv/Inc/health_service.h
@@ -23,7 +23,8 @@
 typedef enum {
   HEALTH_COMPONENT_HEART_BEAT  = (1UL << 0U),
   HEALTH_COMPONENT_TEMPERATURE = (1UL << 1U),
-  HEALTH_COMPONENT_TCP         = (1UL << 2U)
+  HEALTH_COMPONENT_TCP         = (1UL << 2U),
+  HEALTH_COMPONENT_HTTP        = (1UL << 3U)
 } HealthComponent_TypeDef;
 
 /**

--- a/Srv/Inc/http_monitor_service.h
+++ b/Srv/Inc/http_monitor_service.h
@@ -1,0 +1,55 @@
+/**
+  ******************************************************************************
+  * @file           : http_monitor_service.h
+  * @brief          : Periodic HTTP resource health-monitor interface.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#ifndef __HTTP_MONITOR_SERVICE_H
+#define __HTTP_MONITOR_SERVICE_H
+
+#include "main.h"
+#include "device_health.h"
+
+#define HTTP_MONITOR_HOST "hvm-a.ic.local"
+#define HTTP_MONITOR_PORT 3000U
+#define HTTP_MONITOR_PATH "/"
+
+typedef enum {
+  HTTP_MONITOR_ERROR_NONE = 0U,
+  HTTP_MONITOR_ERROR_DNS,
+  HTTP_MONITOR_ERROR_SOCKET,
+  HTTP_MONITOR_ERROR_CONNECT,
+  HTTP_MONITOR_ERROR_SEND,
+  HTTP_MONITOR_ERROR_TIMEOUT,
+  HTTP_MONITOR_ERROR_RESPONSE,
+  HTTP_MONITOR_ERROR_STATUS
+} HttpMonitorError_TypeDef;
+
+/**
+  * @brief Latest result of the configured HTTP resource check.
+  */
+typedef struct {
+  DeviceHealth_TypeDef health;
+  uint16_t statusCode;
+  uint8_t resolvedAddress[4];
+} HttpMonitorSnapshot_TypeDef;
+
+/**
+  * @brief Create the periodic HTTP monitor task and DNS timeout timer.
+  */
+void HttpMonitorService_Init(void);
+
+/**
+  * @brief Copy the latest HTTP monitor result.
+  * @param snapshot (HttpMonitorSnapshot_TypeDef*) Destination snapshot.
+  */
+void HttpMonitorService_GetSnapshot(HttpMonitorSnapshot_TypeDef* snapshot);
+
+#endif /* __HTTP_MONITOR_SERVICE_H */

--- a/Srv/Inc/http_monitor_service.h
+++ b/Srv/Inc/http_monitor_service.h
@@ -18,7 +18,8 @@
 #include "device_health.h"
 
 #define HTTP_MONITOR_HOST "hvm-a.ic.local"
-#define HTTP_MONITOR_PORT 3000U
+#define HTTP_MONITOR_PORT_NUMBER 3000
+#define HTTP_MONITOR_PORT ((uint16_t)HTTP_MONITOR_PORT_NUMBER)
 #define HTTP_MONITOR_PATH "/"
 
 typedef enum {

--- a/Srv/Inc/temperature_service.h
+++ b/Srv/Inc/temperature_service.h
@@ -15,6 +15,7 @@
 #define __TEMPERATURE_SERVICE_H
 
 #include "main.h"
+#include "device_health.h"
 
 #define SENSOR_SERVICE_MAX_DS18B20 6U
 #define SENSOR_SERVICE_MAX_DEVICES (SENSOR_SERVICE_MAX_DS18B20 + 2U)
@@ -39,18 +40,6 @@ typedef enum {
 } SensorCapability_TypeDef;
 
 /**
-  * @brief Availability and health states derived from periodic measurements.
-  */
-typedef enum {
-  SENSOR_HEALTH_INITIALIZING = 0U,
-  SENSOR_HEALTH_HEALTHY,
-  SENSOR_HEALTH_DEGRADED,
-  SENSOR_HEALTH_FAILED,
-  SENSOR_HEALTH_STALE,
-  SENSOR_HEALTH_MISSING
-} SensorHealthState_TypeDef;
-
-/**
   * @brief Errors recorded for the latest unsuccessful measurement.
   */
 typedef enum {
@@ -73,11 +62,7 @@ typedef enum {
   * @param temperature (int32_t) Temperature in hundredths of a degree Celsius.
   * @param pressure (uint32_t) Pressure in pascals.
   * @param humidity (uint32_t) Relative humidity in thousandths of percent.
-  * @param lastAttempt (TickType_t) Tick of the latest measurement attempt.
-  * @param lastSuccess (TickType_t) Tick of the latest successful measurement.
-  * @param consecutiveFailures (uint16_t) Failures since the last success.
-  * @param health (SensorHealthState_TypeDef) Derived sensor health state.
-  * @param lastError (SensorError_TypeDef) Latest measurement error.
+  * @param health (DeviceHealth_TypeDef) Latest availability history.
   */
 typedef struct {
   SensorModel_TypeDef model;
@@ -88,11 +73,7 @@ typedef struct {
   int32_t temperature;
   uint32_t pressure;
   uint32_t humidity;
-  TickType_t lastAttempt;
-  TickType_t lastSuccess;
-  uint16_t consecutiveFailures;
-  SensorHealthState_TypeDef health;
-  SensorError_TypeDef lastError;
+  DeviceHealth_TypeDef health;
 } SensorSnapshot_TypeDef;
 
 /**

--- a/Srv/Src/http_monitor_service.c
+++ b/Srv/Src/http_monitor_service.c
@@ -1,0 +1,312 @@
+/**
+  ******************************************************************************
+  * @file           : http_monitor_service.c
+  * @brief          : Periodic HTTP resource health-monitor implementation.
+  * @project        : STM32F1 Health Check Device
+  * @platform       : STMicroelectronics STM32F103C8
+  * @created        : 27.07.2026
+  ******************************************************************************
+  * @attention
+  * @copyright  : 2017-2026, Dmitry Slobodchikov
+  ******************************************************************************
+  */
+
+#include "http_monitor_service.h"
+#include "DNS/dns.h"
+#include "socket.h"
+#include <string.h>
+
+#define HTTP_MONITOR_SOCKET              4U
+#define HTTP_MONITOR_PERIOD_MS       60000U
+#define HTTP_MONITOR_RESPONSE_MS      5000U
+#define HTTP_MONITOR_LINE_SIZE          64U
+#define HTTP_MONITOR_FAILURE_THRESHOLD   3U
+
+static HttpMonitorSnapshot_TypeDef httpMonitorSnapshot = {
+  .health = {
+    .state = DEVICE_HEALTH_INITIALIZING
+  }
+};
+
+static void httpMonitorService_Task(void* parameters);
+static void httpMonitorService_DnsTimer(TimerHandle_t timer);
+static ErrorStatus httpMonitorService_Check(
+  uint8_t* address,
+  uint16_t* statusCode,
+  HttpMonitorError_TypeDef* error
+);
+static ErrorStatus httpMonitorService_ReadStatus(
+  uint16_t* statusCode,
+  HttpMonitorError_TypeDef* error
+);
+static ErrorStatus httpMonitorService_ParseStatus(
+  const char* line,
+  uint16_t length,
+  uint16_t* statusCode
+);
+static void httpMonitorService_Record(
+  ErrorStatus result,
+  HttpMonitorError_TypeDef error,
+  const uint8_t* address,
+  uint16_t statusCode
+);
+
+
+// -------------------------------------------------------------
+void HttpMonitorService_Init(void) {
+  static StaticTask_t taskControlBlock;
+  static StackType_t taskStack[configMINIMAL_STACK_SIZE * 2U];
+  static StaticTimer_t dnsTimerStorage;
+  TimerHandle_t dnsTimer;
+
+  dnsTimer = xTimerCreateStatic(
+    "DNS tick",
+    pdMS_TO_TICKS(1000U),
+    pdTRUE,
+    NULL,
+    httpMonitorService_DnsTimer,
+    &dnsTimerStorage
+  );
+  if (dnsTimer != NULL) (void)xTimerStart(dnsTimer, 0U);
+
+  (void)xTaskCreateStatic(
+    httpMonitorService_Task,
+    "HTTP Monitor",
+    configMINIMAL_STACK_SIZE * 2U,
+    NULL,
+    configMAX_PRIORITIES - 3U,
+    taskStack,
+    &taskControlBlock
+  );
+}
+
+
+
+
+// -------------------------------------------------------------
+void HttpMonitorService_GetSnapshot(HttpMonitorSnapshot_TypeDef* snapshot) {
+  if (snapshot == NULL) return;
+  taskENTER_CRITICAL();
+  *snapshot = httpMonitorSnapshot;
+  taskEXIT_CRITICAL();
+}
+
+
+
+
+// -------------------------------------------------------------
+static void httpMonitorService_Task(void* parameters) {
+  TickType_t lastWakeTime = xTaskGetTickCount();
+  (void)parameters;
+
+  while (1) {
+    uint8_t address[4] = {0U};
+    uint16_t statusCode = 0U;
+    HttpMonitorError_TypeDef error = HTTP_MONITOR_ERROR_NONE;
+    ErrorStatus result = httpMonitorService_Check(
+      address,
+      &statusCode,
+      &error
+    );
+
+    httpMonitorService_Record(result, error, address, statusCode);
+    printf(
+      "HTTP check: %s, status:%u, error:%u\n",
+      (result == SUCCESS) ? "OK" : "FAILED",
+      statusCode,
+      (unsigned int)error
+    );
+    vTaskDelayUntil(
+      &lastWakeTime,
+      pdMS_TO_TICKS(HTTP_MONITOR_PERIOD_MS)
+    );
+  }
+}
+
+
+
+
+// -------------------------------------------------------------
+static void httpMonitorService_DnsTimer(TimerHandle_t timer) {
+  (void)timer;
+  DNS_time_handler();
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus httpMonitorService_Check(
+  uint8_t* address,
+  uint16_t* statusCode,
+  HttpMonitorError_TypeDef* error
+) {
+  static const uint8_t host[] = HTTP_MONITOR_HOST;
+  static uint8_t request[] =
+    "OPTIONS " HTTP_MONITOR_PATH " HTTP/1.1\r\n"
+    "Host: " HTTP_MONITOR_HOST ":3000\r\n"
+    "Connection: close\r\n"
+    "\r\n";
+  int32_t result;
+  uint8_t dnsServer[4];
+
+  W5500_GetDnsServer(dnsServer);
+  if (DNS_run(dnsServer, (uint8_t*)host, address) != 1) {
+    *error = HTTP_MONITOR_ERROR_DNS;
+    return (ERROR);
+  }
+
+  (void)close(HTTP_MONITOR_SOCKET);
+  if (socket(HTTP_MONITOR_SOCKET, Sn_MR_TCP, 0U, 0U)
+      != HTTP_MONITOR_SOCKET) {
+    *error = HTTP_MONITOR_ERROR_SOCKET;
+    return (ERROR);
+  }
+
+  if (connect(HTTP_MONITOR_SOCKET, address, HTTP_MONITOR_PORT) != SOCK_OK) {
+    *error = HTTP_MONITOR_ERROR_CONNECT;
+    (void)close(HTTP_MONITOR_SOCKET);
+    return (ERROR);
+  }
+
+  result = send(
+    HTTP_MONITOR_SOCKET,
+    request,
+    (uint16_t)(sizeof(request) - 1U)
+  );
+  if (result != (int32_t)(sizeof(request) - 1U)) {
+    *error = HTTP_MONITOR_ERROR_SEND;
+    (void)close(HTTP_MONITOR_SOCKET);
+    return (ERROR);
+  }
+
+  result = httpMonitorService_ReadStatus(statusCode, error);
+  (void)disconnect(HTTP_MONITOR_SOCKET);
+  (void)close(HTTP_MONITOR_SOCKET);
+  if (result != SUCCESS) {
+    return (ERROR);
+  }
+  if (*statusCode != 200U) {
+    *error = HTTP_MONITOR_ERROR_STATUS;
+    return (ERROR);
+  }
+
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus httpMonitorService_ReadStatus(
+  uint16_t* statusCode,
+  HttpMonitorError_TypeDef* error
+) {
+  char line[HTTP_MONITOR_LINE_SIZE];
+  uint16_t length = 0U;
+  TickType_t started = xTaskGetTickCount();
+
+  while ((xTaskGetTickCount() - started)
+         < pdMS_TO_TICKS(HTTP_MONITOR_RESPONSE_MS)) {
+    uint16_t available = getSn_RX_RSR(HTTP_MONITOR_SOCKET);
+
+    if (available > 0U) {
+      uint8_t byte;
+      if (recv(HTTP_MONITOR_SOCKET, &byte, 1U) != 1) {
+        *error = HTTP_MONITOR_ERROR_RESPONSE;
+        return (ERROR);
+      }
+      if (length >= (sizeof(line) - 1U)) {
+        *error = HTTP_MONITOR_ERROR_RESPONSE;
+        return (ERROR);
+      }
+      line[length++] = (char)byte;
+      if ((length >= 2U)
+          && (line[length - 2U] == '\r')
+          && (line[length - 1U] == '\n')) {
+        line[length] = '\0';
+        if (httpMonitorService_ParseStatus(line, length, statusCode)
+            != SUCCESS) {
+          *error = HTTP_MONITOR_ERROR_RESPONSE;
+          return (ERROR);
+        }
+        return (SUCCESS);
+      }
+    } else {
+      uint8_t state = getSn_SR(HTTP_MONITOR_SOCKET);
+      if ((state == SOCK_CLOSED) || (state == SOCK_CLOSE_WAIT)) {
+        *error = HTTP_MONITOR_ERROR_RESPONSE;
+        return (ERROR);
+      }
+      vTaskDelay(pdMS_TO_TICKS(10U));
+    }
+  }
+
+  *error = HTTP_MONITOR_ERROR_TIMEOUT;
+  return (ERROR);
+}
+
+
+
+
+// -------------------------------------------------------------
+static ErrorStatus httpMonitorService_ParseStatus(
+  const char* line,
+  uint16_t length,
+  uint16_t* statusCode
+) {
+  if ((line == NULL) || (statusCode == NULL) || (length < 14U)) {
+    return (ERROR);
+  }
+  if ((memcmp(line, "HTTP/1.", 7U) != 0)
+      || ((line[7] != '0') && (line[7] != '1'))
+      || (line[8] != ' ')
+      || (line[9] < '0') || (line[9] > '9')
+      || (line[10] < '0') || (line[10] > '9')
+      || (line[11] < '0') || (line[11] > '9')) {
+    return (ERROR);
+  }
+
+  *statusCode = (uint16_t)(
+    ((uint16_t)(line[9] - '0') * 100U)
+    + ((uint16_t)(line[10] - '0') * 10U)
+    + (uint16_t)(line[11] - '0')
+  );
+  return (SUCCESS);
+}
+
+
+
+
+// -------------------------------------------------------------
+static void httpMonitorService_Record(
+  ErrorStatus result,
+  HttpMonitorError_TypeDef error,
+  const uint8_t* address,
+  uint16_t statusCode
+) {
+  TickType_t now = xTaskGetTickCount();
+
+  taskENTER_CRITICAL();
+  httpMonitorSnapshot.health.lastAttempt = now;
+  httpMonitorSnapshot.statusCode = statusCode;
+  memcpy(httpMonitorSnapshot.resolvedAddress, address, 4U);
+
+  if (result == SUCCESS) {
+    httpMonitorSnapshot.health.lastSuccess = now;
+    httpMonitorSnapshot.health.consecutiveFailures = 0U;
+    httpMonitorSnapshot.health.lastError = HTTP_MONITOR_ERROR_NONE;
+    httpMonitorSnapshot.health.state = DEVICE_HEALTH_AVAILABLE;
+  } else {
+    if (httpMonitorSnapshot.health.consecutiveFailures < UINT16_MAX) {
+      httpMonitorSnapshot.health.consecutiveFailures++;
+    }
+    httpMonitorSnapshot.health.lastError = (uint8_t)error;
+    httpMonitorSnapshot.health.state =
+      (httpMonitorSnapshot.health.consecutiveFailures
+       >= HTTP_MONITOR_FAILURE_THRESHOLD)
+      ? DEVICE_HEALTH_UNAVAILABLE
+      : DEVICE_HEALTH_DEGRADED;
+  }
+  taskEXIT_CRITICAL();
+}

--- a/Srv/Src/http_monitor_service.c
+++ b/Srv/Src/http_monitor_service.c
@@ -22,6 +22,9 @@
 #define HTTP_MONITOR_LINE_SIZE          64U
 #define HTTP_MONITOR_FAILURE_THRESHOLD   3U
 
+#define HTTP_MONITOR_STRINGIFY_(value) #value
+#define HTTP_MONITOR_STRINGIFY(value) HTTP_MONITOR_STRINGIFY_(value)
+
 static HttpMonitorSnapshot_TypeDef httpMonitorSnapshot = {
   .health = {
     .state = DEVICE_HEALTH_INITIALIZING
@@ -69,6 +72,7 @@ void HttpMonitorService_Init(void) {
   );
   if (dnsTimer != NULL) (void)xTimerStart(dnsTimer, 0U);
 
+  HealthService_Register(HEALTH_COMPONENT_HTTP);
   (void)xTaskCreateStatic(
     httpMonitorService_Task,
     "HTTP Monitor",
@@ -110,6 +114,7 @@ static void httpMonitorService_Task(void* parameters) {
     );
 
     httpMonitorService_Record(result, error, address, statusCode);
+    HealthService_Report(HEALTH_COMPONENT_HTTP);
     printf(
       "HTTP check: %s, status:%u, error:%u\n",
       (result == SUCCESS) ? "OK" : "FAILED",
@@ -142,9 +147,10 @@ static ErrorStatus httpMonitorService_Check(
   HttpMonitorError_TypeDef* error
 ) {
   static const uint8_t host[] = HTTP_MONITOR_HOST;
-  static uint8_t request[] =
+  static const uint8_t request[] =
     "OPTIONS " HTTP_MONITOR_PATH " HTTP/1.1\r\n"
-    "Host: " HTTP_MONITOR_HOST ":3000\r\n"
+    "Host: " HTTP_MONITOR_HOST ":"
+      HTTP_MONITOR_STRINGIFY(HTTP_MONITOR_PORT_NUMBER) "\r\n"
     "Connection: close\r\n"
     "\r\n";
   int32_t result;
@@ -171,7 +177,7 @@ static ErrorStatus httpMonitorService_Check(
 
   result = send(
     HTTP_MONITOR_SOCKET,
-    request,
+    (uint8_t*)request,
     (uint16_t)(sizeof(request) - 1U)
   );
   if (result != (int32_t)(sizeof(request) - 1U)) {

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -45,7 +45,7 @@ static ErrorStatus tcpCommandService_ParseSensorNumber(
   uint8_t*
 );
 static const char* tcpCommandService_ModelName(SensorModel_TypeDef);
-static const char* tcpCommandService_HealthName(SensorHealthState_TypeDef);
+static const char* tcpCommandService_HealthName(DeviceHealthState_TypeDef);
 static const char* tcpCommandService_ErrorName(SensorError_TypeDef);
 static void tcpCommandService_AppendText(char*, size_t, size_t*, const char*);
 static void tcpCommandService_AppendTemperature(char*, size_t, size_t*, int16_t);
@@ -533,27 +533,27 @@ static void tcpHealthService_ProcessCommand(
     return;
   }
 
-  if (snapshot.lastSuccess == 0U) {
+  if (snapshot.health.lastSuccess == 0U) {
     (void)snprintf(
       response,
       sizeof(response),
       "OK model:%s,state:%s,age_ms:unavailable,failures:%u,error:%s\r\n",
       tcpCommandService_ModelName(snapshot.model),
-      tcpCommandService_HealthName(snapshot.health),
-      snapshot.consecutiveFailures,
-      tcpCommandService_ErrorName(snapshot.lastError)
+      tcpCommandService_HealthName(snapshot.health.state),
+      snapshot.health.consecutiveFailures,
+      tcpCommandService_ErrorName((SensorError_TypeDef)snapshot.health.lastError)
     );
   } else {
-    TickType_t age = xTaskGetTickCount() - snapshot.lastSuccess;
+    TickType_t age = xTaskGetTickCount() - snapshot.health.lastSuccess;
     (void)snprintf(
       response,
       sizeof(response),
       "OK model:%s,state:%s,age_ms:%lu,failures:%u,error:%s\r\n",
       tcpCommandService_ModelName(snapshot.model),
-      tcpCommandService_HealthName(snapshot.health),
+      tcpCommandService_HealthName(snapshot.health.state),
       (unsigned long)(age * portTICK_PERIOD_MS),
-      snapshot.consecutiveFailures,
-      tcpCommandService_ErrorName(snapshot.lastError)
+      snapshot.health.consecutiveFailures,
+      tcpCommandService_ErrorName((SensorError_TypeDef)snapshot.health.lastError)
     );
   }
   (void)tcpHealthService_Send(response);
@@ -600,15 +600,15 @@ static const char* tcpCommandService_ModelName(SensorModel_TypeDef model) {
 
 // -------------------------------------------------------------
 static const char* tcpCommandService_HealthName(
-  SensorHealthState_TypeDef health
+  DeviceHealthState_TypeDef health
 ) {
   switch (health) {
-    case SENSOR_HEALTH_INITIALIZING: return ("initializing");
-    case SENSOR_HEALTH_HEALTHY:      return ("healthy");
-    case SENSOR_HEALTH_DEGRADED:     return ("degraded");
-    case SENSOR_HEALTH_FAILED:       return ("failed");
-    case SENSOR_HEALTH_STALE:        return ("stale");
-    case SENSOR_HEALTH_MISSING:      return ("missing");
+    case DEVICE_HEALTH_INITIALIZING: return ("initializing");
+    case DEVICE_HEALTH_AVAILABLE:    return ("healthy");
+    case DEVICE_HEALTH_DEGRADED:     return ("degraded");
+    case DEVICE_HEALTH_UNAVAILABLE:  return ("failed");
+    case DEVICE_HEALTH_STALE:        return ("stale");
+    case DEVICE_HEALTH_MISSING:      return ("missing");
     default:                         return ("unknown");
   }
 }

--- a/Srv/Src/tcp_service.c
+++ b/Srv/Src/tcp_service.c
@@ -80,11 +80,8 @@ static void tcpCommandService_Task(void* parameters) {
   (void) parameters;
 
   while (1) {
-    if (SPI_Enable(SPI1) == SUCCESS) {
-      TcpCommandService_Run();
-      tcpHealthService_Run();
-      (void) SPI_Disable(SPI1);
-    }
+    TcpCommandService_Run();
+    tcpHealthService_Run();
     HealthService_Report(HEALTH_COMPONENT_TCP);
     vTaskDelay(1U);
   }

--- a/Srv/Src/temperature_service.c
+++ b/Srv/Src/temperature_service.c
@@ -240,8 +240,10 @@ static void temperatureSensorService_UpdateSnapshots(
       sensorSnapshots[index] = (SensorSnapshot_TypeDef){
         .model = SENSOR_MODEL_DS18B20,
         .capabilities = SENSOR_CAPABILITY_TEMPERATURE,
-        .health = SENSOR_HEALTH_INITIALIZING,
-        .lastError = SENSOR_ERROR_NOT_READY
+        .health = {
+          .state = DEVICE_HEALTH_INITIALIZING,
+          .lastError = SENSOR_ERROR_NOT_READY
+        }
       };
       memcpy(
         sensorSnapshots[index].identity,
@@ -274,7 +276,7 @@ static void temperatureSensorService_UpdateSnapshots(
         SENSOR_ERROR_MISSING,
         now
       );
-      sensorSnapshots[i].health = SENSOR_HEALTH_MISSING;
+      sensorSnapshots[i].health.state = DEVICE_HEALTH_MISSING;
       sensorSnapshots[i].dataValid = pdFALSE;
     }
   }
@@ -293,8 +295,10 @@ static void temperatureSensorService_UpdateSnapshots(
         .capabilities = SENSOR_CAPABILITY_TEMPERATURE
           | SENSOR_CAPABILITY_PRESSURE
           | ((device->deviceId == BME280_ID) ? SENSOR_CAPABILITY_HUMIDITY : 0U),
-        .health = SENSOR_HEALTH_INITIALIZING,
-        .lastError = SENSOR_ERROR_NOT_READY
+        .health = {
+          .state = DEVICE_HEALTH_INITIALIZING,
+          .lastError = SENSOR_ERROR_NOT_READY
+        }
       };
       sensorSnapshots[index].serialNumber = device->uniqueId;
     }
@@ -321,8 +325,10 @@ static void temperatureSensorService_UpdateSnapshots(
         .capabilities = SENSOR_CAPABILITY_TEMPERATURE
           | SENSOR_CAPABILITY_PRESSURE
           | SENSOR_CAPABILITY_HUMIDITY,
-        .health = SENSOR_HEALTH_INITIALIZING,
-        .lastError = SENSOR_ERROR_NOT_READY
+        .health = {
+          .state = DEVICE_HEALTH_INITIALIZING,
+          .lastError = SENSOR_ERROR_NOT_READY
+        }
       };
       sensorSnapshots[index].serialNumber = device->uniqueId;
     }
@@ -376,24 +382,27 @@ static void temperatureSensorService_RecordResult(
   SensorError_TypeDef error,
   TickType_t now
 ) {
-  snapshot->lastAttempt = now;
+  snapshot->health.lastAttempt = now;
   if (status == SUCCESS) {
     snapshot->dataValid = pdTRUE;
-    snapshot->lastSuccess = now;
-    snapshot->consecutiveFailures = 0U;
-    snapshot->health = SENSOR_HEALTH_HEALTHY;
-    snapshot->lastError = SENSOR_ERROR_NONE;
+    snapshot->health.lastSuccess = now;
+    snapshot->health.consecutiveFailures = 0U;
+    snapshot->health.state = DEVICE_HEALTH_AVAILABLE;
+    snapshot->health.lastError = SENSOR_ERROR_NONE;
     return;
   }
 
-  if (snapshot->consecutiveFailures < UINT16_MAX) {
-    snapshot->consecutiveFailures++;
+  if (snapshot->health.consecutiveFailures < UINT16_MAX) {
+    snapshot->health.consecutiveFailures++;
   }
-  snapshot->lastError = error;
-  snapshot->health = (snapshot->consecutiveFailures >= SENSOR_FAILURE_THRESHOLD)
-    ? SENSOR_HEALTH_FAILED
-    : SENSOR_HEALTH_DEGRADED;
-  if (snapshot->health == SENSOR_HEALTH_FAILED) snapshot->dataValid = pdFALSE;
+  snapshot->health.lastError = (uint8_t)error;
+  snapshot->health.state =
+    (snapshot->health.consecutiveFailures >= SENSOR_FAILURE_THRESHOLD)
+      ? DEVICE_HEALTH_UNAVAILABLE
+      : DEVICE_HEALTH_DEGRADED;
+  if (snapshot->health.state == DEVICE_HEALTH_UNAVAILABLE) {
+    snapshot->dataValid = pdFALSE;
+  }
 }
 
 
@@ -418,12 +427,12 @@ static SensorError_TypeDef temperatureSensorService_MapDs18b20Error(
 static void temperatureSensorService_ApplyAge(
   SensorSnapshot_TypeDef* snapshot
 ) {
-  if ((snapshot->lastSuccess != 0U)
-      && ((snapshot->health == SENSOR_HEALTH_HEALTHY)
-        || (snapshot->health == SENSOR_HEALTH_DEGRADED))
-      && ((xTaskGetTickCount() - snapshot->lastSuccess)
+  if ((snapshot->health.lastSuccess != 0U)
+      && ((snapshot->health.state == DEVICE_HEALTH_AVAILABLE)
+        || (snapshot->health.state == DEVICE_HEALTH_DEGRADED))
+      && ((xTaskGetTickCount() - snapshot->health.lastSuccess)
         > pdMS_TO_TICKS(SENSOR_STALE_PERIOD_MS))) {
-    snapshot->health = SENSOR_HEALTH_STALE;
+    snapshot->health.state = DEVICE_HEALTH_STALE;
     snapshot->dataValid = pdFALSE;
   }
 }


### PR DESCRIPTION
Closes #25

## Summary

- add a periodic FreeRTOS HTTP monitor for http://hvm-a.ic.local:3000/
- resolve the hostname through the DHCP-provided DNS server
- send a minimal OPTIONS / request and treat only HTTP 200 as healthy
- record the latest status, resolved address, failure count, and diagnostic error
- close the dedicated W5500 socket after every successful or failed attempt
- add DNS timeout handling and serialize concurrent W5500 SPI transactions
- refactor and document the W5500 board integration layer
- add W25Q64 SPI flash support and shared peripheral health state
- add PA8/TIM1 passive-buzzer initialization and startup self-test

## Verification

All supported display configurations compile successfully. The existing WIZnet library warnings remain non-critical.